### PR TITLE
fix: add upload_to_release toggle in manual build workflows

### DIFF
--- a/.github/workflows/cd-manual-build-android.yml
+++ b/.github/workflows/cd-manual-build-android.yml
@@ -4,54 +4,76 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish the build (e.g., v4.1.0)'
-        required: true
+        description: 'Tag of the existing release (e.g., v4.1.0). Required if uploading to release.'
+        required: false
       godot_version:
-        description: 'Godot version to build for (e.g., 4.6.0)'
+        description: 'Godot version to build for (e.g., 4.6.0). Note: Android typically only supports stable versions from Maven.'
         required: true
+      upload_to_release:
+        description: 'Upload to GitHub Release? (If false, saves as workflow artifact only)'
+        type: boolean
+        default: true
 
 jobs:
-  check-release:
-    name: Check if release exists
+  setup:
+    name: Parse version and validate
     runs-on: ubuntu-latest
+    outputs:
+      godot_version: ${{ steps.version.outputs.version }}
     steps:
-    - name: Fail if release does not exist
+    - name: Parse and validate version
+      id: version
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.inputs.tag }}
-      run: |
-        if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-          echo "::error::Release $TAG does not exist. This workflow only adds files to existing releases."
-          exit 1
-        fi
-        echo "Release $TAG found. Proceeding with build..."
-
-  android-template: 
-    needs: check-release
-    runs-on: "ubuntu-latest"
-    steps:
-    - uses: actions/checkout@v6
-    
-    - name: Verify godot_version
+        UPLOAD: ${{ github.event.inputs.upload_to_release }}
       run: |
         CV=${{ github.event.inputs.godot_version }}
         if [[ ! "$CV" =~ \. ]]; then CV="${CV}.0"; fi
-        echo "CURRENT_GODOT_VERSION=${CV}" >> $GITHUB_ENV
+        echo "version=${CV}" >> $GITHUB_OUTPUT
+
+        if [ "$UPLOAD" = "true" ]; then
+          if [ -z "$TAG" ]; then
+            echo "::error::Tag is required when uploading to a release."
+            exit 1
+          fi
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release $TAG does not exist. This workflow only adds files to existing releases."
+            exit 1
+          fi
+          echo "Release $TAG found. Will upload to release."
+        else
+          echo "Upload to release is disabled. Artifact will be saved to workflow only."
+        fi
+
+  android-template:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
 
     - name: Build Plugins
       working-directory: platforms/android
       run: |
         chmod +x ./gradlew
-        ./gradlew build -PgodotVersion=${{env.CURRENT_GODOT_VERSION}}
+        ./gradlew build -PgodotVersion=${{ needs.setup.outputs.godot_version }}
 
     - name: Compress the artifact output
       working-directory: platforms/android
       run: |
-        ./gradlew zipPlugins -PgodotVersion="${{env.CURRENT_GODOT_VERSION}}"
-      
-    - name: Upload binary to GitHub Release
+        ./gradlew zipPlugins -PgodotVersion="${{ needs.setup.outputs.godot_version }}"
+
+    - name: Upload to GitHub Release
+      if: github.event.inputs.upload_to_release == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.inputs.tag }}
       run: |
-        gh release upload "$TAG" platforms/android/.output/poing-godot-admob-android-v${{env.CURRENT_GODOT_VERSION}}.zip --clobber --repo "${{ github.repository }}"
+        gh release upload "$TAG" platforms/android/.output/poing-godot-admob-android-v${{ needs.setup.outputs.godot_version }}.zip --clobber --repo "${{ github.repository }}"
+
+    - name: Upload as workflow artifact
+      if: github.event.inputs.upload_to_release == 'false'
+      uses: actions/upload-artifact@v4
+      with:
+        name: poing-godot-admob-android-v${{ needs.setup.outputs.godot_version }}
+        path: platforms/android/.output/poing-godot-admob-android-v${{ needs.setup.outputs.godot_version }}.zip

--- a/.github/workflows/cd-manual-build-ios.yml
+++ b/.github/workflows/cd-manual-build-ios.yml
@@ -4,39 +4,53 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish the build (e.g., v4.1.0)'
-        required: true
+        description: 'Tag of the existing release (e.g., v4.1.0). Required if uploading to release.'
+        required: false
       godot_version:
         description: 'Godot version to build for (e.g., 4.6.0 or 4.7-beta1)'
         required: true
+      upload_to_release:
+        description: 'Upload to GitHub Release? (Uncheck for betas/RCs to only save as workflow artifact)'
+        type: boolean
+        default: true
 
 jobs:
-  check-release:
-    name: Check if release exists
+  setup:
+    name: Parse version and validate
     runs-on: ubuntu-latest
+    outputs:
+      godot_version: ${{ steps.version.outputs.version }}
     steps:
-    - name: Fail if release does not exist
+    - name: Parse and validate version
+      id: version
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.inputs.tag }}
-      run: |
-        if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-          echo "::error::Release $TAG does not exist. This workflow only adds files to existing releases."
-          exit 1
-        fi
-        echo "Release $TAG found. Proceeding with build..."
-
-  ios-template:
-    needs: check-release
-    runs-on: "macos-latest"
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Verify godot_version
+        UPLOAD: ${{ github.event.inputs.upload_to_release }}
       run: |
         CV=${{ github.event.inputs.godot_version }}
-        if [ ${#CV} -eq 1 ]; then CV="${CV}.0"; fi
-        echo "CURRENT_GODOT_VERSION=${CV}" >> $GITHUB_ENV
+        if [[ ! "$CV" =~ \. ]]; then CV="${CV}.0"; fi
+        echo "version=${CV}" >> $GITHUB_OUTPUT
+
+        if [ "$UPLOAD" = "true" ]; then
+          if [ -z "$TAG" ]; then
+            echo "::error::Tag is required when uploading to a release."
+            exit 1
+          fi
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release $TAG does not exist. This workflow only adds files to existing releases."
+            exit 1
+          fi
+          echo "Release $TAG found. Will upload to release."
+        else
+          echo "Upload to release is disabled. Artifact will be saved to workflow only."
+        fi
+
+  ios-template:
+    needs: setup
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v6
 
     - name: Install scons
       uses: actions/setup-python@v6
@@ -45,12 +59,19 @@ jobs:
 
     - name: Build Source
       working-directory: platforms/ios
-      run: ./scripts/build.sh ${{env.CURRENT_GODOT_VERSION}}
+      run: ./scripts/build.sh ${{ needs.setup.outputs.godot_version }}
 
-    - name: Upload binary to GitHub Release
+    - name: Upload to GitHub Release
+      if: github.event.inputs.upload_to_release == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.inputs.tag }}
       run: |
         gh release upload "$TAG" platforms/ios/bin/release/*.zip --clobber --repo "${{ github.repository }}"
 
+    - name: Upload as workflow artifact
+      if: github.event.inputs.upload_to_release == 'false'
+      uses: actions/upload-artifact@v4
+      with:
+        name: poing-godot-admob-ios-v${{ needs.setup.outputs.godot_version }}
+        path: platforms/ios/bin/release/*.zip


### PR DESCRIPTION
## Summary

Fixes the manual build workflows by replacing the implicit/fragile version check with an explicit `upload_to_release` boolean toggle.

## Problem

- Both workflows previously assumed all builds should be uploaded to a GitHub Release.
- If we wanted to compile a beta/rc version (e.g., `4.7-beta1` on iOS) and just test the workflow or save it as an artifact, the script would attempt (and often fail) to upload it.
- Implicitly trying to guess intent via Regex on the `godot_version` string is brittle. Furthermore, Android compiles via Maven AARs, so it typically only works with stable versions, making Regex detection confusing across platforms.

## Changes

- **Added `upload_to_release` boolean input** (defaults to `true`).
- If `true`: requires a `tag` and uploads the generated `.zip` to the GitHub Release.
- If `false`: ignores the `tag` and simply saves the `.zip` as a GitHub Actions workflow artifact.
- Removed the previous `godot_version` regex magic. 
- Updated the input descriptions to clarify that Android usually only supports stable versions from Maven.