### PR TITLE
fix: download missing android/ios binaries synchronously in headless mode

### DIFF
--- a/platforms/godot_editor/addons/admob/admob.gd
+++ b/platforms/godot_editor/addons/admob/admob.gd
@@ -26,6 +26,7 @@ extends EditorPlugin
 const MENU_NAME := "AdMob Manager"
 const AdMobEditorMenu := preload("res://addons/admob/internal/editor/editor_menu.gd")
 const CSharpService := preload("res://addons/admob/internal/services/csharp_service.gd")
+const BinaryInstaller := preload("res://addons/admob/internal/services/network/binary_installer.gd")
 
 var _main_exporter := preload("res://addons/admob/internal/exporters/main_export_plugin.gd").new()
 var _android_exporter := preload("res://addons/admob/internal/exporters/android/export_plugin.gd").new()
@@ -33,6 +34,9 @@ var _ios_exporter := preload("res://addons/admob/internal/exporters/ios/export_p
 
 func _enter_tree() -> void:
 	CSharpService.manage_visibility(self)
+	
+	BinaryInstaller.install_missing_binaries_sync()
+		
 	add_export_plugin(_main_exporter)
 	add_export_plugin(_android_exporter)
 	add_export_plugin(_ios_exporter)

--- a/platforms/godot_editor/addons/admob/internal/exporters/android/export_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/exporters/android/export_plugin.gd
@@ -24,6 +24,7 @@ extends EditorExportPlugin
 
 const Library := preload("res://addons/admob/internal/exporters/android/library.gd")
 const Config := preload("res://addons/admob/android/config.gd")
+const PluginVersion := preload("res://addons/admob/internal/version/plugin_version.gd")
 
 func _get_plugins() -> Array[EditorExportPlugin]:
 	var plugins: Array[EditorExportPlugin]
@@ -37,6 +38,9 @@ func _get_plugins() -> Array[EditorExportPlugin]:
 
 	for lib in config.libraries:
 		if not lib.is_enabled:
+			continue
+		if not FileAccess.file_exists(lib.get_full_path()):
+			push_error("AdMob: Android library not found at " + lib.get_full_path())
 			continue
 		plugins.append(lib.get_plugin())
 	return plugins

--- a/platforms/godot_editor/addons/admob/internal/handlers/android_handler.gd
+++ b/platforms/godot_editor/addons/admob/internal/handlers/android_handler.gd
@@ -46,7 +46,7 @@ func check_dependencies() -> void:
 		install()
 
 func install() -> void:
-	var file_name := _get_zip_file_name()
+	var file_name := get_zip_file_name()
 	var url := BASE_URL % [PluginVersion.current, file_name]
 	var destination := DOWNLOAD_DIR.path_join(file_name)
 	
@@ -56,7 +56,7 @@ func _on_download_completed(success: bool) -> void:
 	if not success:
 		return
 	
-	var file_name := _get_zip_file_name()
+	var file_name := get_zip_file_name()
 	var zip_path := DOWNLOAD_DIR.path_join(file_name)
 	
 	var extract_success := ZipService.extract_zip(zip_path, EXTRACT_PATH, true)
@@ -80,5 +80,5 @@ const VERSION := "%s"
 		file.store_string(content)
 		file.close()
 
-func _get_zip_file_name() -> String:
+static func get_zip_file_name() -> String:
 	return "poing-godot-admob-android-" + PluginVersion.godot + ".zip"

--- a/platforms/godot_editor/addons/admob/internal/handlers/ios_handler.gd
+++ b/platforms/godot_editor/addons/admob/internal/handlers/ios_handler.gd
@@ -45,7 +45,7 @@ func check_dependencies() -> void:
 		install()
 
 func install() -> void:
-	var file_name := _get_zip_file_name()
+	var file_name := get_zip_file_name()
 	var url := BASE_URL % [PluginVersion.current, file_name]
 	var destination := DOWNLOAD_DIR.path_join(file_name)
 	
@@ -55,7 +55,7 @@ func _on_download_completed(success: bool) -> void:
 	if not success:
 		return
 	
-	var file_name := _get_zip_file_name()
+	var file_name := get_zip_file_name()
 	var zip_path := DOWNLOAD_DIR.path_join(file_name)
 	
 	var extract_success := ZipService.extract_zip(zip_path, EXTRACT_PATH, false, ZipService.StripMode.NONE)
@@ -79,5 +79,5 @@ const VERSION := "%s"
 		file.store_string(content)
 		file.close()
 
-func _get_zip_file_name() -> String:
+static func get_zip_file_name() -> String:
 	return "poing-godot-admob-ios-" + PluginVersion.godot + ".zip"

--- a/platforms/godot_editor/addons/admob/internal/services/network/binary_installer.gd
+++ b/platforms/godot_editor/addons/admob/internal/services/network/binary_installer.gd
@@ -1,0 +1,110 @@
+# MIT License
+
+# Copyright (c) 2026-present Poing Studios
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the_conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+const PluginVersion := preload("res://addons/admob/internal/version/plugin_version.gd")
+const ZipService := preload("res://addons/admob/internal/services/archive/zip_service.gd")
+const AndroidHandler := preload("res://addons/admob/internal/handlers/android_handler.gd")
+const IOSHandler := preload("res://addons/admob/internal/handlers/ios_handler.gd")
+
+static func install_missing_binaries_sync() -> void:
+	if DisplayServer.get_name() != "headless":
+		return
+		
+	if not PluginVersion.is_android_installed:
+		_install_android_sync()
+	
+	if not PluginVersion.is_ios_installed:
+		_install_ios_sync()
+
+static func _install_android_sync() -> void:
+	var zip_file_name := AndroidHandler.get_zip_file_name()
+	var url := AndroidHandler.BASE_URL % [PluginVersion.current, zip_file_name]
+	var destination := AndroidHandler.DOWNLOAD_DIR.path_join(zip_file_name)
+	
+	print("AdMob: Headless mode detected and Android binaries are missing. Downloading dynamically...")
+	var success := _download_file_sync(url, destination)
+	if not success:
+		return
+		
+	var extract_success := ZipService.extract_zip(destination, AndroidHandler.EXTRACT_PATH, true, ZipService.StripMode.NONE)
+	if extract_success:
+		_create_package_file(AndroidHandler.PACKAGE_PATH)
+		print("AdMob: Android binaries successfully downloaded and installed!")
+
+static func _install_ios_sync() -> void:
+	var zip_file_name := IOSHandler.get_zip_file_name()
+	var url := IOSHandler.BASE_URL % [PluginVersion.current, zip_file_name]
+	var destination := IOSHandler.DOWNLOAD_DIR.path_join(zip_file_name)
+	
+	print("AdMob: Headless mode detected and iOS binaries are missing. Downloading dynamically...")
+	var success := _download_file_sync(url, destination)
+	if not success:
+		return
+		
+	var extract_success := ZipService.extract_zip(destination, IOSHandler.EXTRACT_PATH, false, ZipService.StripMode.NONE)
+	if extract_success:
+		_create_package_file(IOSHandler.PACKAGE_PATH)
+		print("AdMob: iOS binaries successfully downloaded and installed!")
+
+static func _create_package_file(path: String) -> void:
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file:
+		var content := "# This file is dynamically generated.\n# It defines the current installed version of the platform plugin.\n# Do not modify this manually.\n\nconst VERSION := \"%s\"\n" % PluginVersion.current
+		file.store_string(content)
+		file.close()
+
+static func _download_file_sync(url: String, destination_path: String) -> bool:
+	DirAccess.make_dir_recursive_absolute(destination_path.get_base_dir())
+	var global_dest := ProjectSettings.globalize_path(destination_path)
+	
+	var args := PackedStringArray()
+	var executable := ""
+	
+	if OS.get_name() == "Windows":
+		executable = "powershell"
+		args = PackedStringArray([
+			"-Command",
+			"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%s' -OutFile '%s'" % [url, global_dest]
+		])
+	else:
+		var output := []
+		var exit_code := OS.execute("which", PackedStringArray(["curl"]), output)
+		if exit_code == 0:
+			executable = "curl"
+			args = PackedStringArray(["-L", "-o", global_dest, url])
+		else:
+			exit_code = OS.execute("which", PackedStringArray(["wget"]), output)
+			if exit_code == 0:
+				executable = "wget"
+				args = PackedStringArray(["-O", global_dest, url])
+			else:
+				printerr("AdMob Error: Neither curl nor wget is available for synchronous download.")
+				return false
+				
+	print("AdMob: Downloading synchronously from " + url)
+	var output := []
+	var exit_code := OS.execute(executable, args, output, true)
+	if exit_code != 0:
+		printerr("AdMob Error: Synchronous download failed with exit code %d. Output: %s" % [exit_code, str(output)])
+		return false
+		
+	return true

--- a/platforms/godot_editor/addons/admob/internal/services/network/binary_installer.gd.uid
+++ b/platforms/godot_editor/addons/admob/internal/services/network/binary_installer.gd.uid
@@ -1,0 +1,1 @@
+uid://dj6qds5myxny0

--- a/platforms/godot_editor/addons/admob/internal/services/ui/file_service.gd
+++ b/platforms/godot_editor/addons/admob/internal/services/ui/file_service.gd
@@ -32,12 +32,16 @@ static func write_file(path: String, content: String) -> void:
 static func update_file(path: String) -> void:
 	if not Engine.is_editor_hint() or path.is_empty() or not FileAccess.file_exists(path):
 		return
+	if DisplayServer.get_name() == "headless":
+		return
 	
 	EditorInterface.get_resource_filesystem().update_file(path)
 	refresh_filesystem()
 
 static func refresh_filesystem() -> void:
 	if not Engine.is_editor_hint():
+		return
+	if DisplayServer.get_name() == "headless":
 		return
 		
 	var fs := EditorInterface.get_resource_filesystem()


### PR DESCRIPTION
Resolves #279. Synchronously downloads and extracts missing Android and iOS binaries during plugin initialization in headless mode. Avoids filesystem scans in headless mode to prevent editor conflicts.