### PR TITLE
chore: add tags in the sample project

### DIFF
--- a/platforms/godot_editor/project.godot
+++ b/platforms/godot_editor/project.godot
@@ -77,6 +77,7 @@ config/name="AdMobAddon"
 run/main_scene="uid://0esyp38ds6yg"
 config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://addons/admob/assets/icon-1024.png"
+config/tags=PackedStringArray("admob", "mobile", "plugin", "sample")
 
 [display]
 


### PR DESCRIPTION
Closes #284. Added project tags (`admob`, `mobile`, `plugin`, `sample`) to `project.godot` to make the sample project easier to find and categorize in the Godot Project Manager.