### PR TITLE
chore: add language dropdown to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,6 +27,18 @@ body:
     default: 0
   validations:
     required: true
+- type: dropdown
+  id: language
+  attributes:
+    label: Language
+    description: Are you using GDScript, C#, or both?
+    options:
+      - Both
+      - GDScript
+      - C#
+    default: 0
+  validations:
+    required: true
 - type: input
   attributes:
     label: System information

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,6 +14,18 @@ body:
     default: 0
   validations:
     required: true
+- type: dropdown
+  id: language
+  attributes:
+    label: Language
+    description: Are you using GDScript, C#, or both?
+    options:
+      - Both
+      - GDScript
+      - C#
+    default: 0
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: What feature or improvement would you like to see?


### PR DESCRIPTION
Closes #259. Added a `Language` field to specify if the issue is related to GDScript, C#, or both.