### PR TITLE
ci: fix PR feedback comment when there are no download links

### DIFF
--- a/.github/workflows/ci-pr-feedback.yml
+++ b/.github/workflows/ci-pr-feedback.yml
@@ -50,7 +50,18 @@ jobs:
 
           const getUrl = (artifact) => artifact ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}` : `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
 
-          const body = `✅ **PR Checks Passed!** (Commit: \`${commitSha}\`)\n\n⬇️ **Download Artifacts**\n- 📦 [Android Plugin (\`.aar\` / \`.zip\`)](${getUrl(androidArtifact)})\n- 🍎 [iOS Plugin (\`.xcframework\` / \`.zip\`)](${getUrl(iosArtifact)})\n- 📱 [Test Godot Project APK (GDScript)](${getUrl(apkArtifact)})\n- 🔷 [Test Godot Project APK (C#)](${getUrl(csharpArtifact)})\n- 🍏 [Test Godot Project iOS Simulator App (GDScript)](${getUrl(ipaArtifact)})\n- 🔷 [Test Godot Project iOS Simulator App (C#)](${getUrl(csharpIpaArtifact)})`;
+          let body = `✅ **PR Checks Passed!** (Commit: \`${commitSha}\`)`;
+          
+          const hasArtifacts = androidArtifact || iosArtifact || apkArtifact || csharpArtifact || ipaArtifact || csharpIpaArtifact;
+          if (hasArtifacts) {
+            body += `\n\n⬇️ **Download Artifacts**`;
+            if (androidArtifact) body += `\n- 📦 [Android Plugin (\`.aar\` / \`.zip\`)](${getUrl(androidArtifact)})`;
+            if (iosArtifact) body += `\n- 🍎 [iOS Plugin (\`.xcframework\` / \`.zip\`)](${getUrl(iosArtifact)})`;
+            if (apkArtifact) body += `\n- 📱 [Test Godot Project APK (GDScript)](${getUrl(apkArtifact)})`;
+            if (csharpArtifact) body += `\n- 🔷 [Test Godot Project APK (C#)](${getUrl(csharpArtifact)})`;
+            if (ipaArtifact) body += `\n- 🍏 [Test Godot Project iOS Simulator App (GDScript)](${getUrl(ipaArtifact)})`;
+            if (csharpIpaArtifact) body += `\n- 🔷 [Test Godot Project iOS Simulator App (C#)](${getUrl(csharpIpaArtifact)})`;
+          }
 
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,


### PR DESCRIPTION
The CI script was unconditionally outputting the 'Download Artifacts' block, leading to empty links when the build workflow was skipped or no artifacts were generated (like in PR #300). This PR fixes that by checking if any artifacts exist before adding the download links section to the PR comment.