### PR TITLE
feat: add AdSize selection to sample project UI

### DIFF
--- a/.github/workflows/ci-pr-feedback.yml
+++ b/.github/workflows/ci-pr-feedback.yml
@@ -55,12 +55,12 @@ jobs:
           const hasArtifacts = androidArtifact || iosArtifact || apkArtifact || csharpArtifact || ipaArtifact || csharpIpaArtifact;
           if (hasArtifacts) {
             body += `\n\n⬇️ **Download Artifacts**`;
-            if (androidArtifact) body += `\n- 📦 [Android Plugin (\`.aar\` / \`.zip\`)](${getUrl(androidArtifact)})`;
-            if (iosArtifact) body += `\n- 🍎 [iOS Plugin (\`.xcframework\` / \`.zip\`)](${getUrl(iosArtifact)})`;
-            if (apkArtifact) body += `\n- 📱 [Test Godot Project APK (GDScript)](${getUrl(apkArtifact)})`;
+            if (androidArtifact) body += `\n- 🧩 [Android Plugin (\`.aar\` / \`.zip\`)](${getUrl(androidArtifact)})`;
+            if (iosArtifact) body += `\n- 🧱 [iOS Plugin (\`.xcframework\` / \`.zip\`)](${getUrl(iosArtifact)})`;
+            if (apkArtifact) body += `\n- 🤖 [Test Godot Project APK (GDScript)](${getUrl(apkArtifact)})`;
             if (csharpArtifact) body += `\n- 🔷 [Test Godot Project APK (C#)](${getUrl(csharpArtifact)})`;
-            if (ipaArtifact) body += `\n- 🍏 [Test Godot Project iOS Simulator App (GDScript)](${getUrl(ipaArtifact)})`;
-            if (csharpIpaArtifact) body += `\n- 🔷 [Test Godot Project iOS Simulator App (C#)](${getUrl(csharpIpaArtifact)})`;
+            if (ipaArtifact) body += `\n- 🍎 [Test Godot Project iOS Simulator App (GDScript)](${getUrl(ipaArtifact)})`;
+            if (csharpIpaArtifact) body += `\n- 📱 [Test Godot Project iOS Simulator App (C#)](${getUrl(csharpIpaArtifact)})`;
           }
 
           const { data: comments } = await github.rest.issues.listComments({

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.cs
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.cs
@@ -47,6 +47,7 @@ public partial class Banner : BaseTab
 
 	private LineEdit _xValue;
 	private LineEdit _yValue;
+	private OptionButton _sizeOption;
 
 	public override void _Ready()
 	{
@@ -58,6 +59,7 @@ public partial class Banner : BaseTab
 		_hideBtn = GetNode<Button>("%BannerActions/HideBanner");
 		_getSizeBtn = GetNode<Button>("%BannerActions/GetSize");
 		_collapsibleToggle = GetNode<CheckButton>("%Collapsible");
+		_sizeOption = GetNode<OptionButton>("%SizeOption");
 
 		_loadBtn.Pressed += OnLoadPressed;
 		_loadBackgroundBtn.Pressed += OnLoadBackgroundPressed;
@@ -132,14 +134,31 @@ public partial class Banner : BaseTab
 		return OS.GetName() == "iOS" ? AdUnitIdIos : AdUnitIdAndroid;
 	}
 
+	private AdSize GetSelectedAdSize()
+	{
+		switch (_sizeOption.Selected)
+		{
+			case 0: return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
+			case 1: return AdSize.Banner;
+			case 2: return AdSize.FullBanner;
+			case 3: return AdSize.LargeBanner;
+			case 4: return AdSize.Leaderboard;
+			case 5: return AdSize.MediumRectangle;
+			case 6: return AdSize.WideSkyscraper;
+			case 7: return AdSize.SmartBanner;
+			default: return AdSize.Banner;
+		}
+	}
+
 	private void LoadBanner(bool hideImmediately)
 	{
 		DestroyAd();
 		UpdateUI(false);
 		bool isCollapsibleRequest = _collapsibleToggle.ButtonPressed;
-		Log($"Loading adaptive banner{(hideImmediately ? " in background" : string.Empty)}{(isCollapsibleRequest ? " (collapsible)" : string.Empty)}...");
+		AdSize size = GetSelectedAdSize();
 
-		var size = AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
+		Log($"Loading banner ({_sizeOption.GetItemText(_sizeOption.Selected)}){(hideImmediately ? " in background" : string.Empty)}{(isCollapsibleRequest ? " (collapsible)" : string.Empty)}...");
+
 		_adView = new AdView(GetAdUnitId(isCollapsibleRequest), size, _adPosition);
 		_isHidden = hideImmediately;
 

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.cs
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.cs
@@ -48,6 +48,22 @@ public partial class Banner : BaseTab
 	private LineEdit _xValue;
 	private LineEdit _yValue;
 	private OptionButton _sizeOption;
+	private HBoxContainer _customSize;
+	private LineEdit _widthValue;
+	private LineEdit _heightValue;
+
+	private enum Preset
+	{
+		Adaptive,
+		Banner,
+		FullBanner,
+		LargeBanner,
+		Leaderboard,
+		MediumRectangle,
+		WideSkyscraper,
+		SmartBanner,
+		Custom
+	}
 
 	public override void _Ready()
 	{
@@ -60,6 +76,14 @@ public partial class Banner : BaseTab
 		_getSizeBtn = GetNode<Button>("%BannerActions/GetSize");
 		_collapsibleToggle = GetNode<CheckButton>("%Collapsible");
 		_sizeOption = GetNode<OptionButton>("%SizeOption");
+		_customSize = GetNode<HBoxContainer>("%CustomSize");
+		_widthValue = GetNode<LineEdit>("%WidthValue");
+		_heightValue = GetNode<LineEdit>("%HeightValue");
+
+		_sizeOption.ItemSelected += (index) =>
+		{
+			_customSize.Visible = index == (int)Preset.Custom;
+		};
 
 		_loadBtn.Pressed += OnLoadPressed;
 		_loadBackgroundBtn.Pressed += OnLoadBackgroundPressed;
@@ -96,9 +120,10 @@ public partial class Banner : BaseTab
 		_loadBtn.Disabled = isLoaded;
 		_loadBackgroundBtn.Disabled = isLoaded;
 		_destroyBtn.Disabled = !isLoaded;
-		_showBtn.Disabled = !isLoaded;
-		_hideBtn.Disabled = !isLoaded;
 		_getSizeBtn.Disabled = !isLoaded;
+
+		_showBtn.Disabled = !(isLoaded && _isHidden);
+		_hideBtn.Disabled = !(isLoaded && !_isHidden);
 	}
 
 	private void UpdatePosition(AdPosition pos)
@@ -136,16 +161,22 @@ public partial class Banner : BaseTab
 
 	private AdSize GetSelectedAdSize()
 	{
-		switch (_sizeOption.Selected)
+		switch ((Preset)_sizeOption.Selected)
 		{
-			case 0: return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
-			case 1: return AdSize.Banner;
-			case 2: return AdSize.FullBanner;
-			case 3: return AdSize.LargeBanner;
-			case 4: return AdSize.Leaderboard;
-			case 5: return AdSize.MediumRectangle;
-			case 6: return AdSize.WideSkyscraper;
-			case 7: return AdSize.SmartBanner;
+			case Preset.Adaptive: return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
+			case Preset.Banner: return AdSize.Banner;
+			case Preset.FullBanner: return AdSize.FullBanner;
+			case Preset.LargeBanner: return AdSize.LargeBanner;
+			case Preset.Leaderboard: return AdSize.Leaderboard;
+			case Preset.MediumRectangle: return AdSize.MediumRectangle;
+			case Preset.WideSkyscraper: return AdSize.WideSkyscraper;
+			case Preset.SmartBanner: return AdSize.SmartBanner;
+			case Preset.Custom:
+				if (int.TryParse(_widthValue.Text, out int w) && int.TryParse(_heightValue.Text, out int h))
+				{
+					return new AdSize(w, h);
+				}
+				return AdSize.Banner;
 			default: return AdSize.Banner;
 		}
 	}
@@ -161,6 +192,7 @@ public partial class Banner : BaseTab
 
 		_adView = new AdView(GetAdUnitId(isCollapsibleRequest), size, _adPosition);
 		_isHidden = hideImmediately;
+		UpdateUI(false);
 
 		if (_isHidden)
 		{
@@ -231,6 +263,7 @@ public partial class Banner : BaseTab
 			_isHidden = false;
 			_adView.Show(); 
 			Log("Banner shown"); 
+			UpdateUI(true);
 			SampleRegistry.SafeArea?.UpdateAdOverlap(_adView);
 		}
 	}
@@ -242,6 +275,7 @@ public partial class Banner : BaseTab
 			_isHidden = true;
 			_adView.Hide(); 
 			Log("Banner hidden"); 
+			UpdateUI(true);
 			SampleRegistry.SafeArea?.ResetAdOverlap();
 		}
 	}

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.tscn
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.tscn
@@ -169,7 +169,7 @@ horizontal_alignment = 1
 [node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 8
+item_count = 9
 selected = 0
 popup/item_0/text = "Anchored Adaptive"
 popup/item_0/id = 0
@@ -187,6 +187,43 @@ popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
 popup/item_6/id = 6
 popup/item_7/text = "SMART_BANNER"
 popup/item_7/id = 7
+popup/item_8/text = "CUSTOM"
+popup/item_8/id = 8
+
+[node name="CustomSize" type="HBoxContainer" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 15
+alignment = 1
+
+[node name="WidthLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "W:"
+
+[node name="WidthValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "320"
+placeholder_text = "320"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
+
+[node name="HeightLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "H:"
+
+[node name="HeightValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "50"
+placeholder_text = "50"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
 
 [node name="PositionCard" type="PanelContainer" parent="."]
 layout_mode = 2

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.tscn
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Banner.tscn
@@ -153,6 +153,41 @@ custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Update"
 
+[node name="SizeCard" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_type_variation = &"SectionCard"
+
+[node name="VBox" type="VBoxContainer" parent="SizeCard"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="SizeCard/VBox"]
+layout_mode = 2
+text = "AD SIZE"
+horizontal_alignment = 1
+
+[node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 8
+selected = 0
+popup/item_0/text = "Anchored Adaptive"
+popup/item_0/id = 0
+popup/item_1/text = "BANNER (320x50)"
+popup/item_1/id = 1
+popup/item_2/text = "FULL_BANNER (468x60)"
+popup/item_2/id = 2
+popup/item_3/text = "LARGE_BANNER (320x100)"
+popup/item_3/id = 3
+popup/item_4/text = "LEADERBOARD (728x90)"
+popup/item_4/id = 4
+popup/item_5/text = "MEDIUM_RECTANGLE (300x250)"
+popup/item_5/id = 5
+popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
+popup/item_6/id = 6
+popup/item_7/text = "SMART_BANNER"
+popup/item_7/id = 7
+
 [node name="PositionCard" type="PanelContainer" parent="."]
 layout_mode = 2
 theme_type_variation = &"SectionCard"

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/MobileAds.cs
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/MobileAds.cs
@@ -38,7 +38,7 @@ public partial class MobileAds : BaseTab
 		_iosPauseCheck = GetNode<CheckButton>("iOSAppPause");
 		_muteMusicCheck = GetNode<CheckButton>("MuteMusic");
 		_musicPlayer = GetNode<AudioStreamPlayer>("MusicPlayer");
-		_adVolumeSlider = GetNode<HSlider>("AdVolumeContainer/AdVolumeSlider");
+		_adVolumeSlider = GetNode<HSlider>("AdVolumeCard/AdVolumeContainer/AdVolumeSlider");
 		_adMutedCheck = GetNode<CheckButton>("AdMuted");
 
 		_iosPauseCheck.Toggled += OnSetIosAppPausePressed;

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/MobileAds.tscn
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/MobileAds.tscn
@@ -1,7 +1,21 @@
-[gd_scene format=3 uid="uid://df7xan3v87p5"]
+[gd_scene load_steps=4 format=3 uid="uid://df7xan3v87p5"]
 
 [ext_resource type="Script" path="res://addons/admob/csharp/sample/tabs/MobileAds.cs" id="1_mads"]
 [ext_resource type="AudioStream" uid="uid://f3f176vu6pfo" path="res://addons/admob/assets/music.ogg" id="2_music"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_card"]
+content_margin_left = 30.0
+content_margin_top = 10.0
+content_margin_right = 30.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 1)
+corner_radius_top_left = 100
+corner_radius_top_right = 100
+corner_radius_bottom_right = 100
+corner_radius_bottom_left = 100
+shadow_color = Color(0, 0, 0, 0.1)
+shadow_size = 4
+shadow_offset = Vector2(0, 2)
 
 [node name="MobileAds" type="VBoxContainer"]
 anchors_preset = 15
@@ -31,15 +45,21 @@ layout_mode = 2
 text = "Mute Music"
 alignment = 1
 
-[node name="AdVolumeContainer" type="HBoxContainer" parent="."]
+[node name="AdVolumeCard" type="PanelContainer" parent="."]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_card")
+
+[node name="AdVolumeContainer" type="HBoxContainer" parent="AdVolumeCard"]
 layout_mode = 2
 alignment = 1
 
-[node name="AdVolumeLabel" type="Label" parent="AdVolumeContainer"]
+[node name="AdVolumeLabel" type="Label" parent="AdVolumeCard/AdVolumeContainer"]
 layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "Ad Volume"
 
-[node name="AdVolumeSlider" type="HSlider" parent="AdVolumeContainer"]
+[node name="AdVolumeSlider" type="HSlider" parent="AdVolumeCard/AdVolumeContainer"]
 custom_minimum_size = Vector2(200, 30)
 layout_mode = 2
 size_flags_horizontal = 3

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.cs
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.cs
@@ -20,6 +20,9 @@ namespace PoingStudios.AdMob.Sample
         private LineEdit _xValue;
         private LineEdit _yValue;
         private OptionButton _sizeOption;
+        private HBoxContainer _customSize;
+        private LineEdit _widthValue;
+        private LineEdit _heightValue;
 
         private OptionButton _templateType;
         private Button _mainBgButton;
@@ -29,6 +32,20 @@ namespace PoingStudios.AdMob.Sample
         private Color _mainBgColor = new Color(1, 1, 1, 1);
         private Color _ctaBgColor = new Color(0.258824f, 0.521569f, 0.956863f, 1);
         private Color _ctaTextColor = new Color(1, 1, 1, 1);
+
+        private enum Preset
+        {
+            None,
+            Adaptive,
+            Banner,
+            FullBanner,
+            LargeBanner,
+            Leaderboard,
+            MediumRectangle,
+            WideSkyscraper,
+            SmartBanner,
+            Custom
+        }
 
         public override void _Ready()
         {
@@ -43,6 +60,14 @@ namespace PoingStudios.AdMob.Sample
             _xValue = GetNode<LineEdit>("%XValue");
             _yValue = GetNode<LineEdit>("%YValue");
             _sizeOption = GetNode<OptionButton>("%SizeOption");
+            _customSize = GetNode<HBoxContainer>("%CustomSize");
+            _widthValue = GetNode<LineEdit>("%WidthValue");
+            _heightValue = GetNode<LineEdit>("%HeightValue");
+
+            _sizeOption.ItemSelected += (index) =>
+            {
+                _customSize.Visible = index == (int)Preset.Custom;
+            };
 
             _templateType = GetNode<OptionButton>("%TemplateType");
             _mainBgButton = GetNode<Button>("%MainBGButton");
@@ -112,10 +137,11 @@ namespace PoingStudios.AdMob.Sample
         {
             _loadButton.Disabled = isLoaded;
             _loadBackgroundButton.Disabled = isLoaded;
-            _showButton.Disabled = !isLoaded;
-            _hideButton.Disabled = !isLoaded;
             _destroyButton.Disabled = !isLoaded;
             _getSizeButton.Disabled = !isLoaded;
+
+            _showButton.Disabled = !(isLoaded && _isHidden);
+            _hideButton.Disabled = !(isLoaded && !_isHidden);
         }
 
         private string GetAdUnitId()
@@ -135,6 +161,7 @@ namespace PoingStudios.AdMob.Sample
             Log($"Loading native ad{(hideImmediately ? " in background" : string.Empty)}...");
 
             _isHidden = hideImmediately;
+            UpdateUiState(false);
 
             var options = new NativeAdOptions
             {
@@ -192,16 +219,23 @@ namespace PoingStudios.AdMob.Sample
 
         private AdSize GetSelectedAdSize()
         {
-            switch (_sizeOption.Selected)
+            switch ((Preset)_sizeOption.Selected)
             {
-                case 0: return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
-                case 1: return AdSize.Banner;
-                case 2: return AdSize.FullBanner;
-                case 3: return AdSize.LargeBanner;
-                case 4: return AdSize.Leaderboard;
-                case 5: return AdSize.MediumRectangle;
-                case 6: return AdSize.WideSkyscraper;
-                case 7: return AdSize.SmartBanner;
+                case Preset.None: return null;
+                case Preset.Adaptive: return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
+                case Preset.Banner: return AdSize.Banner;
+                case Preset.FullBanner: return AdSize.FullBanner;
+                case Preset.LargeBanner: return AdSize.LargeBanner;
+                case Preset.Leaderboard: return AdSize.Leaderboard;
+                case Preset.MediumRectangle: return AdSize.MediumRectangle;
+                case Preset.WideSkyscraper: return AdSize.WideSkyscraper;
+                case Preset.SmartBanner: return AdSize.SmartBanner;
+                case Preset.Custom:
+                    if (int.TryParse(_widthValue.Text, out int w) && int.TryParse(_heightValue.Text, out int h))
+                    {
+                        return new AdSize(w, h);
+                    }
+                    return null;
                 default: return null;
             }
         }
@@ -227,6 +261,7 @@ namespace PoingStudios.AdMob.Sample
                 _isHidden = false;
                 _nativeOverlayAd.Show();
                 Log("Native shown");
+                UpdateUiState(true);
             }
         }
 
@@ -237,6 +272,7 @@ namespace PoingStudios.AdMob.Sample
                 _isHidden = true;
                 _nativeOverlayAd.Hide();
                 Log("Native hidden");
+                UpdateUiState(true);
             }
         }
 

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.cs
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.cs
@@ -19,6 +19,7 @@ namespace PoingStudios.AdMob.Sample
         private Button _getSizeButton;
         private LineEdit _xValue;
         private LineEdit _yValue;
+        private OptionButton _sizeOption;
 
         private OptionButton _templateType;
         private Button _mainBgButton;
@@ -41,6 +42,7 @@ namespace PoingStudios.AdMob.Sample
             _getSizeButton = GetNode<Button>("%GetSize");
             _xValue = GetNode<LineEdit>("%XValue");
             _yValue = GetNode<LineEdit>("%YValue");
+            _sizeOption = GetNode<OptionButton>("%SizeOption");
 
             _templateType = GetNode<OptionButton>("%TemplateType");
             _mainBgButton = GetNode<Button>("%MainBGButton");
@@ -178,7 +180,7 @@ namespace PoingStudios.AdMob.Sample
                 }
             };
 
-            _nativeOverlayAd.RenderTemplate(style, _adPosition);
+            _nativeOverlayAd.RenderTemplate(style, _adPosition, GetSelectedAdSize());
 
             if (_isHidden)
             {
@@ -186,6 +188,22 @@ namespace PoingStudios.AdMob.Sample
             }
 
             UpdateUiState(true);
+        }
+
+        private AdSize GetSelectedAdSize()
+        {
+            switch (_sizeOption.Selected)
+            {
+                case 0: return AdSize.GetCurrentOrientationAnchoredAdaptiveBannerAdSize(AdSize.FullWidth);
+                case 1: return AdSize.Banner;
+                case 2: return AdSize.FullBanner;
+                case 3: return AdSize.LargeBanner;
+                case 4: return AdSize.Leaderboard;
+                case 5: return AdSize.MediumRectangle;
+                case 6: return AdSize.WideSkyscraper;
+                case 7: return AdSize.SmartBanner;
+                default: return null;
+            }
         }
 
         public void _on_load_native_pressed() => LoadNative(false);

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.tscn
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.tscn
@@ -272,6 +272,41 @@ custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Update"
 
+[node name="SizeCard" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_type_variation = &"SectionCard"
+
+[node name="VBox" type="VBoxContainer" parent="SizeCard"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="SizeCard/VBox"]
+layout_mode = 2
+text = "AD SIZE"
+horizontal_alignment = 1
+
+[node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 8
+selected = 0
+popup/item_0/text = "Anchored Adaptive"
+popup/item_0/id = 0
+popup/item_1/text = "BANNER (320x50)"
+popup/item_1/id = 1
+popup/item_2/text = "FULL_BANNER (468x60)"
+popup/item_2/id = 2
+popup/item_3/text = "LARGE_BANNER (320x100)"
+popup/item_3/id = 3
+popup/item_4/text = "LEADERBOARD (728x90)"
+popup/item_4/id = 4
+popup/item_5/text = "MEDIUM_RECTANGLE (300x250)"
+popup/item_5/id = 5
+popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
+popup/item_6/id = 6
+popup/item_7/text = "SMART_BANNER"
+popup/item_7/id = 7
+
 [node name="PositionCard" type="PanelContainer" parent="."]
 layout_mode = 2
 theme_type_variation = &"SectionCard"

--- a/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.tscn
+++ b/platforms/godot_editor/addons/admob/csharp/sample/tabs/Native.tscn
@@ -288,24 +288,64 @@ horizontal_alignment = 1
 [node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 8
+item_count = 10
 selected = 0
-popup/item_0/text = "Anchored Adaptive"
+popup/item_0/text = "Default (None)"
 popup/item_0/id = 0
-popup/item_1/text = "BANNER (320x50)"
+popup/item_1/text = "Anchored Adaptive"
 popup/item_1/id = 1
-popup/item_2/text = "FULL_BANNER (468x60)"
+popup/item_2/text = "BANNER (320x50)"
 popup/item_2/id = 2
-popup/item_3/text = "LARGE_BANNER (320x100)"
+popup/item_3/text = "FULL_BANNER (468x60)"
 popup/item_3/id = 3
-popup/item_4/text = "LEADERBOARD (728x90)"
+popup/item_4/text = "LARGE_BANNER (320x100)"
 popup/item_4/id = 4
-popup/item_5/text = "MEDIUM_RECTANGLE (300x250)"
+popup/item_5/text = "LEADERBOARD (728x90)"
 popup/item_5/id = 5
-popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
+popup/item_6/text = "MEDIUM_RECTANGLE (300x250)"
 popup/item_6/id = 6
-popup/item_7/text = "SMART_BANNER"
+popup/item_7/text = "WIDE_SKYSCRAPER (160x600)"
 popup/item_7/id = 7
+popup/item_8/text = "SMART_BANNER"
+popup/item_8/id = 8
+popup/item_9/text = "CUSTOM"
+popup/item_9/id = 9
+
+[node name="CustomSize" type="HBoxContainer" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 15
+alignment = 1
+
+[node name="WidthLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "W:"
+
+[node name="WidthValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "320"
+placeholder_text = "320"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
+
+[node name="HeightLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "H:"
+
+[node name="HeightValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "250"
+placeholder_text = "250"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
+
 
 [node name="PositionCard" type="PanelContainer" parent="."]
 layout_mode = 2

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.gd
@@ -38,6 +38,7 @@ var _is_hidden := false
 @onready var _collapsible_toggle: CheckButton = %Collapsible
 @onready var _x_value: LineEdit = %XValue
 @onready var _y_value: LineEdit = %YValue
+@onready var _size_option: OptionButton = %SizeOption
 
 func _ready() -> void:
 	super()
@@ -63,18 +64,32 @@ func _get_ad_unit_id(is_collapsible: bool = false) -> String:
 		return "ca-app-pub-3940256099942544/2014213617" if OS.get_name() == "Android" else "ca-app-pub-3940256099942544/8388050270"
 	return "ca-app-pub-3940256099942544/6300978111" if OS.get_name() == "Android" else "ca-app-pub-3940256099942544/2934735716"
 
+func _get_selected_ad_size() -> AdSize:
+	match _size_option.selected:
+		0: return AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
+		1: return AdSize.BANNER
+		2: return AdSize.FULL_BANNER
+		3: return AdSize.LARGE_BANNER
+		4: return AdSize.LEADERBOARD
+		5: return AdSize.MEDIUM_RECTANGLE
+		6: return AdSize.WIDE_SKYSCRAPER
+		7: return AdSize.SMART_BANNER
+	return AdSize.BANNER
+
 func _load_banner(hide_immediately: bool = false) -> void:
 	if _ad_view:
 		_ad_view.destroy()
 	
 	_update_ui_state(false)
 	var is_collapsible_request := _collapsible_toggle.button_pressed
-	_log("Loading adaptive banner%s%s..." % [
+	var ad_size := _get_selected_ad_size()
+	
+	_log("Loading banner (%s)%s%s..." % [
+		_size_option.get_item_text(_size_option.selected),
 		" in background" if hide_immediately else "",
 		" (collapsible)" if is_collapsible_request else ""
 	])
 	
-	var ad_size := AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
 	_ad_view = AdView.new(_get_ad_unit_id(is_collapsible_request), ad_size, _ad_position)
 	_ad_view.ad_listener = _ad_listener
 	_ad_view.on_ad_paid = func(ad_value: AdValue) -> void:

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.gd
@@ -39,6 +39,22 @@ var _is_hidden := false
 @onready var _x_value: LineEdit = %XValue
 @onready var _y_value: LineEdit = %YValue
 @onready var _size_option: OptionButton = %SizeOption
+@onready var _custom_size := %CustomSize as HBoxContainer
+@onready var _width_value: LineEdit = %WidthValue
+@onready var _height_value: LineEdit = %HeightValue
+
+
+enum Preset {
+	ADAPTIVE,
+	BANNER,
+	FULL_BANNER,
+	LARGE_BANNER,
+	LEADERBOARD,
+	MEDIUM_RECTANGLE,
+	WIDE_SKYSCRAPER,
+	SMART_BANNER,
+	CUSTOM
+}
 
 func _ready() -> void:
 	super()
@@ -49,15 +65,20 @@ func _ready() -> void:
 	_ad_listener.on_ad_loaded = _on_ad_loaded
 	_ad_listener.on_ad_opened = _on_ad_opened
 	
+	_size_option.item_selected.connect(func(index: int) -> void:
+		_custom_size.visible = index == Preset.CUSTOM
+	)
+	
 	_update_ui_state(false)
 
 func _update_ui_state(is_loaded: bool) -> void:
 	_load_button.disabled = is_loaded
 	_load_background_button.disabled = is_loaded
-	_show_button.disabled = !is_loaded
-	_hide_button.disabled = !is_loaded
 	_destroy_button.disabled = !is_loaded
 	_get_size_button.disabled = !is_loaded
+	
+	_show_button.disabled = not (is_loaded and _is_hidden)
+	_hide_button.disabled = not (is_loaded and not _is_hidden)
 
 func _get_ad_unit_id(is_collapsible: bool = false) -> String:
 	if is_collapsible:
@@ -66,14 +87,15 @@ func _get_ad_unit_id(is_collapsible: bool = false) -> String:
 
 func _get_selected_ad_size() -> AdSize:
 	match _size_option.selected:
-		0: return AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
-		1: return AdSize.BANNER
-		2: return AdSize.FULL_BANNER
-		3: return AdSize.LARGE_BANNER
-		4: return AdSize.LEADERBOARD
-		5: return AdSize.MEDIUM_RECTANGLE
-		6: return AdSize.WIDE_SKYSCRAPER
-		7: return AdSize.SMART_BANNER
+		Preset.ADAPTIVE: return AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
+		Preset.BANNER: return AdSize.BANNER
+		Preset.FULL_BANNER: return AdSize.FULL_BANNER
+		Preset.LARGE_BANNER: return AdSize.LARGE_BANNER
+		Preset.LEADERBOARD: return AdSize.LEADERBOARD
+		Preset.MEDIUM_RECTANGLE: return AdSize.MEDIUM_RECTANGLE
+		Preset.WIDE_SKYSCRAPER: return AdSize.WIDE_SKYSCRAPER
+		Preset.SMART_BANNER: return AdSize.SMART_BANNER
+		Preset.CUSTOM: return AdSize.new(int(_width_value.text), int(_height_value.text))
 	return AdSize.BANNER
 
 func _load_banner(hide_immediately: bool = false) -> void:
@@ -103,6 +125,7 @@ func _load_banner(hide_immediately: bool = false) -> void:
 		_log("Ad paid: %f %s (precision: %d, source: %s)" % [ad_value.value_micros / 1000000.0, ad_value.currency_code, ad_value.precision, ad_source_name])
 	
 	_is_hidden = hide_immediately
+	_update_ui_state(false)
 	if _is_hidden:
 		_ad_view.hide()
 	
@@ -134,6 +157,7 @@ func _on_show_banner_pressed() -> void:
 		_is_hidden = false
 		_ad_view.show()
 		_log("Banner shown")
+		_update_ui_state(true)
 		if Registry.safe_area:
 			Registry.safe_area.update_ad_overlap(_ad_view)
 
@@ -142,6 +166,7 @@ func _on_hide_banner_pressed() -> void:
 		_is_hidden = true
 		_ad_view.hide()
 		_log("Banner hidden")
+		_update_ui_state(true)
 		if Registry.safe_area:
 			Registry.safe_area.reset_ad_overlap()
 

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.tscn
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.tscn
@@ -153,6 +153,41 @@ custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Update"
 
+[node name="SizeCard" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_type_variation = &"SectionCard"
+
+[node name="VBox" type="VBoxContainer" parent="SizeCard"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="SizeCard/VBox"]
+layout_mode = 2
+text = "AD SIZE"
+horizontal_alignment = 1
+
+[node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 8
+selected = 0
+popup/item_0/text = "Anchored Adaptive"
+popup/item_0/id = 0
+popup/item_1/text = "BANNER (320x50)"
+popup/item_1/id = 1
+popup/item_2/text = "FULL_BANNER (468x60)"
+popup/item_2/id = 2
+popup/item_3/text = "LARGE_BANNER (320x100)"
+popup/item_3/id = 3
+popup/item_4/text = "LEADERBOARD (728x90)"
+popup/item_4/id = 4
+popup/item_5/text = "MEDIUM_RECTANGLE (300x250)"
+popup/item_5/id = 5
+popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
+popup/item_6/id = 6
+popup/item_7/text = "SMART_BANNER"
+popup/item_7/id = 7
+
 [node name="PositionCard" type="PanelContainer" parent="." unique_id=208169234]
 layout_mode = 2
 theme_type_variation = &"SectionCard"

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.tscn
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Banner.tscn
@@ -169,7 +169,7 @@ horizontal_alignment = 1
 [node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 8
+item_count = 9
 selected = 0
 popup/item_0/text = "Anchored Adaptive"
 popup/item_0/id = 0
@@ -187,6 +187,43 @@ popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
 popup/item_6/id = 6
 popup/item_7/text = "SMART_BANNER"
 popup/item_7/id = 7
+popup/item_8/text = "CUSTOM"
+popup/item_8/id = 8
+
+[node name="CustomSize" type="HBoxContainer" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 15
+alignment = 1
+
+[node name="WidthLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "W:"
+
+[node name="WidthValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "320"
+placeholder_text = "320"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
+
+[node name="HeightLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "H:"
+
+[node name="HeightValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "50"
+placeholder_text = "50"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
 
 [node name="PositionCard" type="PanelContainer" parent="." unique_id=208169234]
 layout_mode = 2

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/MobileAds.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/MobileAds.gd
@@ -27,7 +27,7 @@ const Registry = preload("res://addons/admob/internal/sample_registry.gd")
 @onready var _ios_pause_check: CheckButton = $iOSAppPause
 @onready var _mute_music_check: CheckButton = $MuteMusic
 @onready var _music_player: AudioStreamPlayer = $MusicPlayer
-@onready var _ad_volume_slider: HSlider = $AdVolumeContainer/AdVolumeSlider
+@onready var _ad_volume_slider: HSlider = $AdVolumeCard/AdVolumeContainer/AdVolumeSlider
 @onready var _ad_muted_check: CheckButton = $AdMuted
 
 func _on_get_initialization_status_pressed() -> void:

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/MobileAds.tscn
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/MobileAds.tscn
@@ -1,7 +1,21 @@
-[gd_scene load_steps=3 format=3 uid="uid://df7w8m2v87p5"]
+[gd_scene load_steps=4 format=3 uid="uid://df7w8m2v87p5"]
 
 [ext_resource type="Script" path="res://addons/admob/gdscript/sample/tabs/MobileAds.gd" id="1_mads"]
 [ext_resource type="AudioStream" uid="uid://f3f176vu6pfo" path="res://addons/admob/assets/music.ogg" id="2_music"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_card"]
+content_margin_left = 30.0
+content_margin_top = 10.0
+content_margin_right = 30.0
+content_margin_bottom = 10.0
+bg_color = Color(1, 1, 1, 1)
+corner_radius_top_left = 100
+corner_radius_top_right = 100
+corner_radius_bottom_right = 100
+corner_radius_bottom_left = 100
+shadow_color = Color(0, 0, 0, 0.1)
+shadow_size = 4
+shadow_offset = Vector2(0, 2)
 
 [node name="MobileAds" type="VBoxContainer"]
 anchors_preset = 15
@@ -31,15 +45,21 @@ layout_mode = 2
 text = "Mute Music"
 alignment = 1
 
-[node name="AdVolumeContainer" type="HBoxContainer" parent="."]
+[node name="AdVolumeCard" type="PanelContainer" parent="."]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_card")
+
+[node name="AdVolumeContainer" type="HBoxContainer" parent="AdVolumeCard"]
 layout_mode = 2
 alignment = 1
 
-[node name="AdVolumeLabel" type="Label" parent="AdVolumeContainer"]
+[node name="AdVolumeLabel" type="Label" parent="AdVolumeCard/AdVolumeContainer"]
 layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "Ad Volume"
 
-[node name="AdVolumeSlider" type="HSlider" parent="AdVolumeContainer"]
+[node name="AdVolumeSlider" type="HSlider" parent="AdVolumeCard/AdVolumeContainer"]
 custom_minimum_size = Vector2(200, 30)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -61,5 +81,5 @@ autoplay = true
 [connection signal="pressed" from="GetInitStatus" to="." method="_on_get_initialization_status_pressed"]
 [connection signal="toggled" from="iOSAppPause" to="." method="_on_set_ios_app_pause_on_background_button_pressed"]
 [connection signal="toggled" from="MuteMusic" to="." method="_on_mute_music_pressed"]
-[connection signal="value_changed" from="AdVolumeContainer/AdVolumeSlider" to="." method="_on_ad_volume_changed"]
+[connection signal="value_changed" from="AdVolumeCard/AdVolumeContainer/AdVolumeSlider" to="." method="_on_ad_volume_changed"]
 [connection signal="toggled" from="AdMuted" to="." method="_on_ad_muted_pressed"]

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.gd
@@ -36,6 +36,7 @@ var _is_hidden := false
 @onready var _get_size_button: Button = %GetSize
 @onready var _x_value: LineEdit = %XValue
 @onready var _y_value: LineEdit = %YValue
+@onready var _size_option: OptionButton = %SizeOption
 
 @onready var _template_type: OptionButton = %TemplateType
 @onready var _main_bg_button: Button = %MainBGButton
@@ -154,12 +155,24 @@ func _on_ad_load_finished(ad: NativeOverlayAd, error: LoadAdError) -> void:
 	
 	style.call_to_action_text = cta_style
 	
-	_native_overlay_ad.render_template(style, _ad_position)
+	_native_overlay_ad.render_template(style, _ad_position, _get_selected_ad_size())
 	
 	if _is_hidden:
 		_native_overlay_ad.hide()
 		
 	_update_ui_state(true)
+
+func _get_selected_ad_size() -> AdSize:
+	match _size_option.selected:
+		0: return AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
+		1: return AdSize.BANNER
+		2: return AdSize.FULL_BANNER
+		3: return AdSize.LARGE_BANNER
+		4: return AdSize.LEADERBOARD
+		5: return AdSize.MEDIUM_RECTANGLE
+		6: return AdSize.WIDE_SKYSCRAPER
+		7: return AdSize.SMART_BANNER
+	return null
 
 func _on_load_native_pressed() -> void:
 	_load_native(false)

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.gd
@@ -37,6 +37,9 @@ var _is_hidden := false
 @onready var _x_value: LineEdit = %XValue
 @onready var _y_value: LineEdit = %YValue
 @onready var _size_option: OptionButton = %SizeOption
+@onready var _custom_size := %CustomSize as HBoxContainer
+@onready var _width_value: LineEdit = %WidthValue
+@onready var _height_value: LineEdit = %HeightValue
 
 @onready var _template_type: OptionButton = %TemplateType
 @onready var _main_bg_button: Button = %MainBGButton
@@ -47,11 +50,30 @@ var _main_bg_color := Color(1, 1, 1, 1)
 var _cta_bg_color := Color(0.258824, 0.521569, 0.956863, 1)
 var _cta_text_color := Color(1, 1, 1, 1)
 
+
+enum Preset {
+	NONE,
+	ADAPTIVE,
+	BANNER,
+	FULL_BANNER,
+	LARGE_BANNER,
+	LEADERBOARD,
+	MEDIUM_RECTANGLE,
+	WIDE_SKYSCRAPER,
+	SMART_BANNER,
+	CUSTOM
+}
+
 func _ready() -> void:
 	super()
 	_main_bg_button.pressed.connect(_on_main_bg_button_pressed)
 	_cta_bg_button.pressed.connect(_on_cta_bg_button_pressed)
 	_cta_text_button.pressed.connect(_on_cta_text_button_pressed)
+	
+	_size_option.item_selected.connect(func(index: int) -> void:
+		_custom_size.visible = index == Preset.CUSTOM
+	)
+	
 	_update_ui_state(false)
 
 func _update_button_color(button: Button, color: Color) -> void:
@@ -93,10 +115,11 @@ func _on_cta_text_button_pressed() -> void:
 func _update_ui_state(is_loaded: bool) -> void:
 	_load_button.disabled = is_loaded
 	_load_background_button.disabled = is_loaded
-	_show_button.disabled = !is_loaded
-	_hide_button.disabled = !is_loaded
 	_destroy_button.disabled = !is_loaded
 	_get_size_button.disabled = !is_loaded
+	
+	_show_button.disabled = not (is_loaded and _is_hidden)
+	_hide_button.disabled = not (is_loaded and not _is_hidden)
 
 func _get_ad_unit_id() -> String:
 	return "ca-app-pub-3940256099942544/2247696110" if OS.get_name() == "Android" else "ca-app-pub-3940256099942544/3986624511"
@@ -110,6 +133,7 @@ func _load_native(hide_immediately: bool = false) -> void:
 	_log("Loading native ad%s..." % (" in background" if hide_immediately else ""))
 	
 	_is_hidden = hide_immediately
+	_update_ui_state(false)
 	
 	var options := NativeAdOptions.new()
 	options.ad_choices_placement = AdChoicesPlacement.Values.TOP_RIGHT
@@ -164,14 +188,16 @@ func _on_ad_load_finished(ad: NativeOverlayAd, error: LoadAdError) -> void:
 
 func _get_selected_ad_size() -> AdSize:
 	match _size_option.selected:
-		0: return AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
-		1: return AdSize.BANNER
-		2: return AdSize.FULL_BANNER
-		3: return AdSize.LARGE_BANNER
-		4: return AdSize.LEADERBOARD
-		5: return AdSize.MEDIUM_RECTANGLE
-		6: return AdSize.WIDE_SKYSCRAPER
-		7: return AdSize.SMART_BANNER
+		Preset.NONE: return null
+		Preset.ADAPTIVE: return AdSize.get_current_orientation_anchored_adaptive_banner_ad_size(AdSize.FULL_WIDTH)
+		Preset.BANNER: return AdSize.BANNER
+		Preset.FULL_BANNER: return AdSize.FULL_BANNER
+		Preset.LARGE_BANNER: return AdSize.LARGE_BANNER
+		Preset.LEADERBOARD: return AdSize.LEADERBOARD
+		Preset.MEDIUM_RECTANGLE: return AdSize.MEDIUM_RECTANGLE
+		Preset.WIDE_SKYSCRAPER: return AdSize.WIDE_SKYSCRAPER
+		Preset.SMART_BANNER: return AdSize.SMART_BANNER
+		Preset.CUSTOM: return AdSize.new(int(_width_value.text), int(_height_value.text))
 	return null
 
 func _on_load_native_pressed() -> void:
@@ -192,12 +218,14 @@ func _on_show_native_pressed() -> void:
 		_is_hidden = false
 		_native_overlay_ad.show()
 		_log("Native shown")
+		_update_ui_state(true)
 
 func _on_hide_native_pressed() -> void:
 	if _native_overlay_ad:
 		_is_hidden = true
 		_native_overlay_ad.hide()
 		_log("Native hidden")
+		_update_ui_state(true)
 
 func _on_get_size_pressed() -> void:
 	if _native_overlay_ad:

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.tscn
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.tscn
@@ -326,24 +326,63 @@ horizontal_alignment = 1
 [node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 8
+item_count = 10
 selected = 0
-popup/item_0/text = "Anchored Adaptive"
+popup/item_0/text = "Default (None)"
 popup/item_0/id = 0
-popup/item_1/text = "BANNER (320x50)"
+popup/item_1/text = "Anchored Adaptive"
 popup/item_1/id = 1
-popup/item_2/text = "FULL_BANNER (468x60)"
+popup/item_2/text = "BANNER (320x50)"
 popup/item_2/id = 2
-popup/item_3/text = "LARGE_BANNER (320x100)"
+popup/item_3/text = "FULL_BANNER (468x60)"
 popup/item_3/id = 3
-popup/item_4/text = "LEADERBOARD (728x90)"
+popup/item_4/text = "LARGE_BANNER (320x100)"
 popup/item_4/id = 4
-popup/item_5/text = "MEDIUM_RECTANGLE (300x250)"
+popup/item_5/text = "LEADERBOARD (728x90)"
 popup/item_5/id = 5
-popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
+popup/item_6/text = "MEDIUM_RECTANGLE (300x250)"
 popup/item_6/id = 6
-popup/item_7/text = "SMART_BANNER"
+popup/item_7/text = "WIDE_SKYSCRAPER (160x600)"
 popup/item_7/id = 7
+popup/item_8/text = "SMART_BANNER"
+popup/item_8/id = 8
+popup/item_9/text = "CUSTOM"
+popup/item_9/id = 9
+
+[node name="CustomSize" type="HBoxContainer" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 15
+alignment = 1
+
+[node name="WidthLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "W:"
+
+[node name="WidthValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "320"
+placeholder_text = "320"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
+
+[node name="HeightLabel" type="Label" parent="SizeCard/VBox/CustomSize"]
+layout_mode = 2
+text = "H:"
+
+[node name="HeightValue" type="LineEdit" parent="SizeCard/VBox/CustomSize"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+text = "250"
+placeholder_text = "250"
+alignment = 1
+select_all_on_focus = true
+virtual_keyboard_type = 2
 
 [node name="PositionCard" type="PanelContainer" parent="."]
 layout_mode = 2

--- a/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.tscn
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/tabs/Native.tscn
@@ -310,6 +310,41 @@ custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Update"
 
+[node name="SizeCard" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_type_variation = &"SectionCard"
+
+[node name="VBox" type="VBoxContainer" parent="SizeCard"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="SizeCard/VBox"]
+layout_mode = 2
+text = "AD SIZE"
+horizontal_alignment = 1
+
+[node name="SizeOption" type="OptionButton" parent="SizeCard/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 8
+selected = 0
+popup/item_0/text = "Anchored Adaptive"
+popup/item_0/id = 0
+popup/item_1/text = "BANNER (320x50)"
+popup/item_1/id = 1
+popup/item_2/text = "FULL_BANNER (468x60)"
+popup/item_2/id = 2
+popup/item_3/text = "LARGE_BANNER (320x100)"
+popup/item_3/id = 3
+popup/item_4/text = "LEADERBOARD (728x90)"
+popup/item_4/id = 4
+popup/item_5/text = "MEDIUM_RECTANGLE (300x250)"
+popup/item_5/id = 5
+popup/item_6/text = "WIDE_SKYSCRAPER (160x600)"
+popup/item_6/id = 6
+popup/item_7/text = "SMART_BANNER"
+popup/item_7/id = 7
+
 [node name="PositionCard" type="PanelContainer" parent="."]
 layout_mode = 2
 theme_type_variation = &"SectionCard"

--- a/platforms/godot_editor/project.godot
+++ b/platforms/godot_editor/project.godot
@@ -74,10 +74,10 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="AdMobAddon"
-run/main_scene="uid://0esyp38ds6yg"
-config/features=PackedStringArray("4.6", "GL Compatibility")
-config/icon="res://addons/admob/assets/icon-1024.png"
 config/tags=PackedStringArray("admob", "mobile", "plugin", "sample")
+run/main_scene="uid://0esyp38ds6yg"
+config/features=PackedStringArray("4.6", "C#", "GL Compatibility")
+config/icon="res://addons/admob/assets/icon-1024.png"
 
 [display]
 


### PR DESCRIPTION
Closes #268. Users can now select between standard AdMob sizes (Banner, Full Banner, Large Banner, Leaderboard, Medium Rectangle, Wide Skyscraper, Smart Banner) and Anchored Adaptive banners in the sample project's Banner and Native tabs, mirroring the existing AdPosition selection logic.