### PR TITLE
Use badgen instead of shields.io

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -21,7 +21,8 @@ jobs:
             - 'platforms/**'
             - 'scripts/**'
             - '.github/workflows/**'
-            - '!**.md'
+            - '!**/*.md'
+            - '!*.md'
 
   detect-latest:
     name: Check latest Godot version

--- a/README.md
+++ b/README.md
@@ -518,21 +518,21 @@ If you appreciate our work, don't forget to give us a star on GitHub! ⭐
 
 ![Star History Chart](https://api.star-history.com/svg?repos=poingstudios/godot-admob-plugin&type=Date)
 
-[VersionBadge]: https://img.shields.io/github/v/tag/poingstudios/godot-admob-plugin?style=flat&label=Version
-[StarsBadge]: https://img.shields.io/github/stars/poingstudios/godot-admob-plugin?style=flat
-[DiscordBadge]: https://img.shields.io/badge/Discord-7289DA?style=flat&logo=discord&logoColor=white
-[LicenseBadge]: https://img.shields.io/github/license/poingstudios/godot-admob-plugin?style=flat&label=License
-[DownloadsBadge]: https://img.shields.io/github/downloads/poingstudios/godot-admob-plugin/total?style=flat&label=Downloads&color=darkgreen
-[AssetLibraryBadge]: https://img.shields.io/badge/Download-Asset%20Library-darkgreen?style=flat
-[AndroidBadge]: https://img.shields.io/badge/Android-3DDC84?style=flat&logo=android&logoColor=white
-[iOSBadge]: https://img.shields.io/badge/iOS-000000?style=flat&logo=ios&logoColor=white
-[GDScriptBadge]: https://img.shields.io/badge/GDScript-478CBF?style=flat&logo=godot-engine&logoColor=white
-[CSharpBadge]: https://img.shields.io/badge/C%23-239120?style=flat&logo=csharp&logoColor=white
-[PatreonBadge]: https://img.shields.io/badge/Support%20us%20on-Patreon-orange?style=for-the-badge&logo=patreon
-[KofiBadge]: https://img.shields.io/badge/Buy%20us%20a-coffee-yellow?style=for-the-badge&logo=ko-fi
-[PaypalBadge]: https://img.shields.io/badge/Donate-via%20Paypal-blue?style=for-the-badge&logo=paypal
-[DiscussionsBadge]: https://img.shields.io/badge/Discussions-green?style=for-the-badge
-[DiscordHelpBadge]: https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white
+[VersionBadge]: https://badgen.net/github/release/poingstudios/godot-admob-plugin?label=Version
+[StarsBadge]: https://badgen.net/github/stars/poingstudios/godot-admob-plugin
+[DiscordBadge]: https://badgen.net/badge/Discord/join/7289DA?icon=discord
+[LicenseBadge]: https://badgen.net/github/license/poingstudios/godot-admob-plugin?label=License
+[DownloadsBadge]: https://badgen.net/github/assets-dl/poingstudios/godot-admob-plugin?label=Downloads&color=green
+[AssetLibraryBadge]: https://badgen.net/badge/Download/Asset%20Library/green
+[AndroidBadge]: https://badgen.net/badge/_/Android/3DDC84?label=&icon=android
+[iOSBadge]: https://badgen.net/badge/_/iOS/000000?label=&icon=apple
+[GDScriptBadge]: https://badgen.net/badge/_/GDScript/478CBF?label=&icon=godotengine
+[CSharpBadge]: https://badgen.net/badge/_/C%23/239120?label=&icon=csharp
+[PatreonBadge]: https://badgen.net/badge/Support%20us%20on/Patreon/orange?icon=patreon
+[KofiBadge]: https://badgen.net/badge/Buy%20us%20a/coffee/yellow?icon=kofi
+[PaypalBadge]: https://badgen.net/badge/Donate/via%20Paypal/blue?icon=paypal
+[DiscussionsBadge]: https://badgen.net/badge/Discussions/green/green
+[DiscordHelpBadge]: https://badgen.net/badge/Discord/join/7289DA?icon=discord
 
 [DocumentationLink]: https://poingstudios.github.io/godot-admob-plugin/latest/
 [Releases]: https://github.com/poingstudios/godot-admob-plugin/releases

--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -11,16 +11,16 @@
 
 <p align="center">
   <a href="https://github.com/poingstudios/godot-admob-android/releases">
-    <img src="https://img.shields.io/github/v/tag/poingstudios/godot-admob-android?style=flat&label=Version">
+    <img src="https://badgen.net/github/release/poingstudios/godot-admob-android?label=Version">
   </a>
   <a href="https://github.com/poingstudios/godot-admob-android/actions/workflows/release_android.yml">
     <img src="https://github.com/poingstudios/godot-admob-android/actions/workflows/release_android.yml/badge.svg">
   </a>
   <a href="https://github.com/poingstudios/godot-admob-plugin/releases">
-    <img src="https://img.shields.io/github/downloads/poingstudios/godot-admob-plugin/total?style=flat">
+    <img src="https://badgen.net/github/assets-dl/poingstudios/godot-admob-plugin?label=Downloads&color=green">
   </a>
-  <img src="https://img.shields.io/github/stars/poingstudios/godot-admob-android?style=flat">
-  <img src="https://img.shields.io/github/license/poingstudios/godot-admob-android?style=flat&label=License">
+  <img src="https://badgen.net/github/stars/poingstudios/godot-admob-android">
+  <img src="https://badgen.net/github/license/poingstudios/godot-admob-android?label=License">
 </p>
 
 <p align="center">
@@ -82,18 +82,18 @@ Alternatively, you can check the docs of AdMob itself of [Android](https://devel
 ## 🙏 Support
 If you find our work valuable and would like to support us, consider contributing via these platforms:
 
-[![Patreon](https://img.shields.io/badge/Support%20us%20on-Patreon-orange?style=for-the-badge&logo=patreon)](https://patreon.com/poingstudios)
+[![Patreon](https://badgen.net/badge/Support%20us%20on/Patreon/orange?icon=patreon)](https://patreon.com/poingstudios)
 
-[![Ko-fi](https://img.shields.io/badge/Buy%20us%20a-coffee-yellow?style=for-the-badge&logo=ko-fi)](https://ko-fi.com/poingstudios)
+[![Ko-fi](https://badgen.net/badge/Buy%20us%20a/coffee/yellow?icon=kofi)](https://ko-fi.com/poingstudios)
 
-[![Paypal](https://img.shields.io/badge/Donate-via%20Paypal-blue?style=for-the-badge&logo=paypal)](https://www.paypal.com/donate/?hosted_button_id=EBUVPEGF4BUR8)
+[![Paypal](https://badgen.net/badge/Donate/via%20Paypal/blue?icon=paypal)](https://www.paypal.com/donate/?hosted_button_id=EBUVPEGF4BUR8)
 
 Your support helps us continue to improve and maintain this plugin. Thank you for being a part of our community!
 
 
 ## 🆘Getting help
-[![DISCUSSIONS](https://img.shields.io/badge/Discussions-green?style=for-the-badge)](https://github.com/poingstudios/godot-admob-android/discussions)
-[![DISCORD](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge)](https://discord.com/invite/YEPvYjSSMk)
+[![DISCUSSIONS](https://badgen.net/badge/Discussions/green/green)](https://github.com/poingstudios/godot-admob-android/discussions)
+[![DISCORD](https://badgen.net/badge/Discord/join/7289DA?icon=discord)](https://discord.com/invite/YEPvYjSSMk)
 
 
 ## Development

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -11,16 +11,16 @@
 
 <p align="center">
   <a href="https://github.com/poingstudios/godot-admob-ios/releases">
-    <img src="https://img.shields.io/github/v/tag/poingstudios/godot-admob-ios?style=flat&label=Version">
+    <img src="https://badgen.net/github/release/poingstudios/godot-admob-ios?label=Version">
   </a>
   <a href="https://github.com/poingstudios/godot-admob-ios/actions/workflows/release_ios.yml">
     <img src="https://github.com/poingstudios/godot-admob-ios/actions/workflows/release_ios.yml/badge.svg">
   </a>
   <a href="https://github.com/poingstudios/godot-admob-plugin/releases">
-    <img src="https://img.shields.io/github/downloads/poingstudios/godot-admob-plugin/total?style=flat">
+    <img src="https://badgen.net/github/assets-dl/poingstudios/godot-admob-plugin?label=Downloads&color=green">
   </a>
-  <img src="https://img.shields.io/github/stars/poingstudios/godot-admob-ios?style=flat">
-  <img src="https://img.shields.io/github/license/poingstudios/godot-admob-ios?style=flat&label=License">
+  <img src="https://badgen.net/github/stars/poingstudios/godot-admob-ios">
+  <img src="https://badgen.net/github/license/poingstudios/godot-admob-ios?label=License">
 </p>
 
 <p align="center">
@@ -82,18 +82,18 @@ Alternatively, you can check the docs of AdMob itself of [iOS](https://developer
 ## 🙏 Support
 If you find our work valuable and would like to support us, consider contributing via these platforms:
 
-[![Patreon](https://img.shields.io/badge/Support%20us%20on-Patreon-orange?style=for-the-badge&logo=patreon)](https://patreon.com/poingstudios)
+[![Patreon](https://badgen.net/badge/Support%20us%20on/Patreon/orange?icon=patreon)](https://patreon.com/poingstudios)
 
-[![Ko-fi](https://img.shields.io/badge/Buy%20us%20a-coffee-yellow?style=for-the-badge&logo=ko-fi)](https://ko-fi.com/poingstudios)
+[![Ko-fi](https://badgen.net/badge/Buy%20us%20a/coffee/yellow?icon=kofi)](https://ko-fi.com/poingstudios)
 
-[![Paypal](https://img.shields.io/badge/Donate-via%20Paypal-blue?style=for-the-badge&logo=paypal)](https://www.paypal.com/donate/?hosted_button_id=EBUVPEGF4BUR8)
+[![Paypal](https://badgen.net/badge/Donate/via%20Paypal/blue?icon=paypal)](https://www.paypal.com/donate/?hosted_button_id=EBUVPEGF4BUR8)
 
 Your support helps us continue to improve and maintain this plugin. Thank you for being a part of our community!
 
 
 ## 🆘Getting help
-[![DISCUSSIONS](https://img.shields.io/badge/Discussions-green?style=for-the-badge)](https://github.com/poingstudios/godot-admob-ios/discussions)
-[![DISCORD](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge)](https://discord.com/invite/YEPvYjSSMk)
+[![DISCUSSIONS](https://badgen.net/badge/Discussions/green/green)](https://github.com/poingstudios/godot-admob-ios/discussions)
+[![DISCORD](https://badgen.net/badge/Discord/join/7289DA?icon=discord)](https://discord.com/invite/YEPvYjSSMk)
 
 
 ## ⭐ Star History


### PR DESCRIPTION
Closes #313. Migrates all status and static badges in all READMEs to Badgen.net to resolve Shields.io GitHub token pool rate limiting issues.