### PR TITLE
feat: support Godot pre-releases for Android plugin builds

### DIFF
--- a/.github/workflows/cd-build-and-release.yml
+++ b/.github/workflows/cd-build-and-release.yml
@@ -43,6 +43,8 @@ jobs:
     - name: Build Plugins
       working-directory: platforms/android
       run: |
+        chmod +x ./scripts/unix/download_godot.sh
+        ./scripts/unix/download_godot.sh ${{matrix.GODOT_VERSIONS}}
         chmod +x ./gradlew
         ./gradlew build -PgodotVersion=${{matrix.GODOT_VERSIONS}}
 

--- a/.github/workflows/cd-manual-build-android.yml
+++ b/.github/workflows/cd-manual-build-android.yml
@@ -7,7 +7,7 @@ on:
         description: 'Tag of the existing release (e.g., v4.1.0). Required if uploading to release.'
         required: false
       godot_version:
-        description: 'Godot version to build for (e.g., 4.6.0). Note: Android typically only supports stable versions from Maven.'
+        description: 'Godot version to build for (e.g., 4.6.3 or 4.7-rc3)'
         required: true
       upload_to_release:
         description: 'Upload to GitHub Release? (If false, saves as workflow artifact only)'
@@ -55,6 +55,8 @@ jobs:
     - name: Build Plugins
       working-directory: platforms/android
       run: |
+        chmod +x ./scripts/unix/download_godot.sh
+        ./scripts/unix/download_godot.sh ${{ needs.setup.outputs.godot_version }}
         chmod +x ./gradlew
         ./gradlew build -PgodotVersion=${{ needs.setup.outputs.godot_version }}
 

--- a/platforms/android/.gitignore
+++ b/platforms/android/.gitignore
@@ -13,3 +13,4 @@ local.properties
 
 *.aar
 *.zip
+/godot-lib/

--- a/platforms/android/scripts/unix/clean_build.sh
+++ b/platforms/android/scripts/unix/clean_build.sh
@@ -31,6 +31,7 @@ fi
 CURRENT_GODOT_VERSION="$1"
 
 chmod +x ./scripts/unix/download_godot.sh
+./scripts/unix/download_godot.sh "$CURRENT_GODOT_VERSION"
 ./gradlew clean
 ./gradlew build -PgodotVersion="$CURRENT_GODOT_VERSION"
 

--- a/platforms/android/scripts/unix/download_godot.sh
+++ b/platforms/android/scripts/unix/download_godot.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# MIT License
+#
+# Copyright (c) 2023-present Poing Studios
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# platforms/android/scripts/unix/download_godot.sh
+
+if [ $# -eq 0 ]; then
+    echo "[ERROR] Please provide the Godot version as an argument."
+    exit 1
+fi
+
+GODOT_VERSION="$1"
+LIB_DIR="godot-lib"
+VERSION_FILE="${LIB_DIR}/.version"
+
+# Check if already downloaded and matching
+if [ -f "$VERSION_FILE" ]; then
+    INSTALLED_VER=$(cat "$VERSION_FILE")
+    if [ "$INSTALLED_VER" == "$GODOT_VERSION" ] && [ -f "${LIB_DIR}/godot-lib.aar" ]; then
+        echo "[INFO] godot-lib.aar for version $GODOT_VERSION is already downloaded. Skipping."
+        exit 0
+    fi
+fi
+
+# Determine repo and tag name
+# E.g. stable version 4.6.3 vs pre-release 4.7-rc3
+if [[ "$GODOT_VERSION" =~ (beta|rc|dev) ]]; then
+    GODOT_TAG="$GODOT_VERSION"
+    GODOT_REPO="godotengine/godot-builds"
+else
+    # Check if suffix -stable is already present, if not append it
+    if [[ "$GODOT_VERSION" == *-stable ]]; then
+        GODOT_TAG="$GODOT_VERSION"
+    else
+        GODOT_TAG="${GODOT_VERSION}-stable"
+    fi
+    GODOT_REPO="godotengine/godot"
+fi
+
+# Replace '-' with '.' in the tag for the asset name
+# E.g. 4.7-rc3 -> 4.7.rc3
+# E.g. 4.6.3-stable -> 4.6.3.stable
+GODOT_TAG_DOTS="${GODOT_TAG//-/.}"
+ASSET_NAME="godot-lib.${GODOT_TAG_DOTS}.template_release.aar"
+DOWNLOAD_URL="https://github.com/${GODOT_REPO}/releases/download/${GODOT_TAG}/${ASSET_NAME}"
+
+echo "[INFO] Downloading godot-lib.aar from: $DOWNLOAD_URL"
+
+mkdir -p "$LIB_DIR"
+TEMP_FILE="${LIB_DIR}/temp_godot_lib.aar"
+
+if ! curl -f -L -o "$TEMP_FILE" "$DOWNLOAD_URL"; then
+    echo "[ERROR] Failed to download godot-lib.aar from $DOWNLOAD_URL"
+    rm -f "$TEMP_FILE"
+    exit 1
+fi
+
+mv "$TEMP_FILE" "${LIB_DIR}/godot-lib.aar"
+echo "$GODOT_VERSION" > "$VERSION_FILE"
+
+echo "[SUCCESS] godot-lib.aar version $GODOT_VERSION downloaded successfully."

--- a/platforms/android/settings.gradle
+++ b/platforms/android/settings.gradle
@@ -12,6 +12,9 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url 'https://android-sdk.is.com/' }
         maven { url "https://artifactory.bidmachine.io/bidmachine" }
+        flatDir {
+            dirs 'godot-lib'
+        }
     }
 }
 

--- a/platforms/android/src/core/build.gradle
+++ b/platforms/android/src/core/build.gradle
@@ -38,13 +38,19 @@ dependencies {
         project.dependencies.add("api", item.toString())
     }
 
-    def godotVersion    = project.findProperty("godotVersion") ?: "4.6.0"
-    def releaseType     = project.findProperty("releaseType") ?: "stable"
+    def localGodotLib = rootProject.file("godot-lib/godot-lib.aar")
+    if (localGodotLib.exists()) {
+        println "Using local godot-lib from ${localGodotLib.absolutePath}"
+        api(name: 'godot-lib', ext: 'aar')
+    } else {
+        def godotVersion    = project.findProperty("godotVersion") ?: "4.7.0"
+        def releaseType     = project.findProperty("releaseType") ?: "stable"
 
-    def fullVersion = "$godotVersion.$releaseType"
-    println "Using remote godot-lib on version $fullVersion"
+        def fullVersion = "$godotVersion.$releaseType"
+        println "Using remote godot-lib on version $fullVersion"
 
-    api "org.godotengine:godot:$fullVersion"
+        api "org.godotengine:godot:$fullVersion"
+    }
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
     testImplementation 'junit:junit:4.13.2'

--- a/platforms/android/src/core/build.gradle
+++ b/platforms/android/src/core/build.gradle
@@ -39,13 +39,13 @@ dependencies {
     }
 
     def localGodotLib = rootProject.file("godot-lib/godot-lib.aar")
+    def godotVersion    = project.findProperty("godotVersion") ?: "4.7.0"
+    def releaseType     = project.findProperty("releaseType") ?: "stable"
+
     if (localGodotLib.exists()) {
         println "Using local godot-lib from ${localGodotLib.absolutePath}"
         api(name: 'godot-lib', ext: 'aar')
     } else {
-        def godotVersion    = project.findProperty("godotVersion") ?: "4.7.0"
-        def releaseType     = project.findProperty("releaseType") ?: "stable"
-
         def fullVersion = "$godotVersion.$releaseType"
         println "Using remote godot-lib on version $fullVersion"
 

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -31,9 +31,9 @@ show_help() {
     echo "  <godot_version>  The Godot version (e.g., 4.6.1 or 4.7-beta1)"
     echo ""
     echo "Examples:"
-    echo "  ./scripts/build_local.sh all 4.6.1"
-    echo "  ./scripts/build_local.sh ios 4.7-beta1"
-    echo "  ./scripts/build_local.sh android 4.6.1"
+    echo "  ./scripts/build_local.sh all 4.6.3"
+    echo "  ./scripts/build_local.sh ios 4.7-rc3"
+    echo "  ./scripts/build_local.sh android 4.6.3"
 }
 
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
@@ -54,7 +54,10 @@ DEST="$ROOT_DIR/platforms/godot_editor"
 
 build_android() {
     echo ">>> Building Android ($GODOT_VERSION)..."
-    cd "$ROOT_DIR/platforms/android" && chmod +x gradlew && \
+    cd "$ROOT_DIR/platforms/android" && \
+    chmod +x ./scripts/unix/download_godot.sh && \
+    ./scripts/unix/download_godot.sh "$GODOT_VERSION" && \
+    chmod +x gradlew && \
     ./gradlew build -PgodotVersion="$GODOT_VERSION" && \
     ./gradlew exportFiles -PpluginExportPath="$DEST/addons/admob/android/bin" || exit 1
 }


### PR DESCRIPTION
This PR adds support for building Android templates with beta/rc versions of Godot by downloading the godot-lib.aar file and referencing it locally via a flatDir repository.