### PR TITLE
ci: add mkdocs-static-i18n dependency to cd-deploy-docs

### DIFF
--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install mkdocs-material pillow cairosvg mike mkdocs-awesome-pages-plugin
+      - run: pip install mkdocs-material pillow cairosvg mike mkdocs-awesome-pages-plugin mkdocs-static-i18n
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Fixes the [CD] Deploy Documentation workflow failing with 'The "i18n" plugin is not installed' after merging the i18n support.