### PR TITLE
docs: add site_url to mkdocs.yml to resolve i18n redirect paths

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Godot AdMob Plugin - Poing Studios
+site_url: https://poingstudios.github.io/godot-admob-plugin/
 extra_css:
   - stylesheets/extra.css
 extra_javascript:


### PR DESCRIPTION
Resolves language switcher redirecting to absolute domain root (causing 404 on GitHub Pages).