### PR TITLE
docs: re-enable hooks.py for dynamic copyright year replacement

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,3 +157,6 @@ nav:
     - Classes:
       - AdView: reference/classes/AdView.md
     - Enums: reference/enums.md
+
+hooks:
+  - docs/hooks.py


### PR DESCRIPTION
Restores dynamic replacement of the `{current_year}` placeholder in the copyright footer using `docs/hooks.py`.