### PR TITLE
feat: Add Zucks Mediation for Android, clean iOS wrappers, and fix DTExchange/iMobile config

### DIFF
--- a/docs/mediate/integrate_partner_networks/zucks.md
+++ b/docs/mediate/integrate_partner_networks/zucks.md
@@ -1,0 +1,56 @@
+# Integrate Zucks with Mediation
+
+This guide explains how to utilize the Google Mobile Ads SDK to load and present ads from Zucks through [mediation](../get_started.md). It provides instructions on integrating Zucks into the mediation configuration of a Godot app and integrating the Zucks SDK and adapter.
+
+This document is based on:
+
+- [Google Mobile Ads SDK Android Documentation](https://developers.google.com/admob/android/mediation/zucks)
+- [Google Mobile Ads SDK iOS Documentation](https://developers.google.com/admob/ios/mediation/zucks)
+
+## Supported integrations and ad formats
+
+The AdMob mediation adapter for Zucks has the following capabilities:
+
+| Integration |   |
+|-------------|---|
+| Bidding     |   |
+| Waterfall   | ✅ |
+
+| Formats               |            |
+|-----------------------|------------|
+| Banner                | ✅          |
+| Interstitial          | ✅          |
+| Rewarded              |            |
+| Rewarded Interstitial |            |
+| Native                |            |
+
+## Prerequisites
+- Complete the [Get started guide](../../index.md)
+- Complete the mediation [Get started guide](../get_started.md)
+
+## Step 1: Set up Zucks
+We recommend following the tutorial for [Android](https://developers.google.com/admob/android/mediation/zucks#step_1_set_up_zucks) or [iOS](https://developers.google.com/admob/ios/mediation/zucks#step_1_set_up_zucks), as it will be the same for both.
+
+## Step 2: Configure mediation settings for your AdMob ad unit
+We recommend following the tutorial for [Android](https://developers.google.com/admob/android/mediation/zucks#step_2) or [iOS](https://developers.google.com/admob/ios/mediation/zucks#step_2), as it will be the same for both.
+
+## Step 3: Import the Zucks SDK plugin
+
+=== "Android"
+    1. Download the plugin for [Android](https://github.com/poingstudios/godot-admob-android/releases/latest).
+    2. Extract the `.zip` file. Inside, you will find a `zucks` folder.
+    3. Copy the contents of the `zucks` folder and paste them into the Android plugin folder at `res://addons/admob/android/bin/`.
+
+=== "iOS"
+    As Zucks is integrated via Custom Events on iOS, developers must manually add the Zucks SDK and AdMob adapter framework files to their Xcode project after export.
+
+## Step 4: Enable the plugin
+
+=== "Android"
+    Make sure to enable **Zucks** in **Project Settings** (under `Admob > Android > Mediation > Zucks`).
+
+=== "iOS"
+    For iOS, there is no plugin checkbox in the Godot Export window. You just need to check the main `Ad Mob` plugin, export your project, and then manually link the Zucks frameworks in Xcode.
+
+## Step 5: Optional steps (Regulatory Settings)
+Zucks does not require any additional custom code configuration for GDPR or CCPA settings via the Google Mobile Ads adapter API. Consent and privacy settings are managed through standard AdMob dashboard configuration or platform-level options.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -337,6 +337,7 @@ nav:
         - Pangle: mediate/integrate_partner_networks/pangle.md
         - PubMatic: mediate/integrate_partner_networks/pubmatic.md
         - Vpon: mediate/integrate_partner_networks/vpon.md
+        - Zucks: mediate/integrate_partner_networks/zucks.md
     - Privacy:
       - Regulatory solutions:
         - US states privacy laws: privacy/regulatory_solutions/us_states_privacy_laws.md

--- a/platforms/android/settings.gradle
+++ b/platforms/android/settings.gradle
@@ -21,6 +21,7 @@ dependencyResolutionManagement {
         maven { url "https://artifact.bytedance.com/repository/pangle/" }
         maven { url "https://repo.pubmatic.com/artifactory/public-repos" }
         maven { url "https://m.vpon.com/sdk/android/maven" }
+        maven { url "https://raw.githubusercontent.com/zucks/ZucksAdNetworkSDK-Maven/master" }
         flatDir {
             dirs 'godot-lib'
         }
@@ -48,3 +49,4 @@ include ':src:mediation:mytarget'
 include ':src:mediation:pangle'
 include ':src:mediation:pubmatic'
 include ':src:mediation:vpon'
+include ':src:mediation:zucks'

--- a/platforms/android/settings.gradle
+++ b/platforms/android/settings.gradle
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
         maven { url "https://artifact.bytedance.com/repository/pangle/" }
         maven { url "https://repo.pubmatic.com/artifactory/public-repos" }
         maven { url "https://m.vpon.com/sdk/android/maven" }
-        maven { url "https://raw.githubusercontent.com/zucks/ZucksAdNetworkSDK-Maven/master" }
+        maven { url "https://raw.githubusercontent.com/zucks/ZucksAdNetworkSDK-Maven/admob-6.1.0.1" }
         flatDir {
             dirs 'godot-lib'
         }

--- a/platforms/android/src/mediation/line/config/poing_godot_admob_line.gd
+++ b/platforms/android/src/mediation/line/config/poing_godot_admob_line.gd
@@ -23,7 +23,7 @@
 extends EditorExportPlugin
 
 const PLUGIN_NAME := "line"
-var _dependency_library := ["com.google.ads.mediation:line:3.1.0.0"]
+var _dependency_library := ["com.google.ads.mediation:line:3.0.1.1"]
 
 
 func _supports_platform(platform: EditorExportPlatform) -> bool:

--- a/platforms/android/src/mediation/vpon/config/poing_godot_admob_vpon.gd
+++ b/platforms/android/src/mediation/vpon/config/poing_godot_admob_vpon.gd
@@ -23,7 +23,7 @@
 extends EditorExportPlugin
 
 const PLUGIN_NAME := "vpon"
-var _dependency_library := [""]
+var _dependency_library := [ ]
 
 
 func _supports_platform(platform: EditorExportPlatform) -> bool:

--- a/platforms/android/src/mediation/zucks/build.gradle
+++ b/platforms/android/src/mediation/zucks/build.gradle
@@ -38,8 +38,6 @@ dependencies {
         project.dependencies.add("compileOnly", item.toString())
     }
 
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'com.google.android.material:material:1.13.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'

--- a/platforms/android/src/mediation/zucks/build.gradle
+++ b/platforms/android/src/mediation/zucks/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace = "com.poingstudios.godot.admob.zucks"
+
+    defaultConfig {
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles "consumer-rules.pro"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    def fullModuleName = rootProject.ext.buildFullModuleName(project)
+
+    libraryVariants.configureEach { variant ->
+        variant.outputs.all {
+            outputFileName = "${fullModuleName}-${variant.name}.aar"
+            println "Output file will be: $outputFileName"
+        }
+    }
+}
+
+dependencies {
+    def libs = rootProject.ext.readDependencyLibrary(
+            file("config/poing_godot_admob_zucks.gd")
+    )
+
+    libs.each { item ->
+        println "compileOnly item: $item"
+        project.dependencies.add("compileOnly", item.toString())
+    }
+
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+}

--- a/platforms/android/src/mediation/zucks/config/poing_godot_admob_zucks.gd
+++ b/platforms/android/src/mediation/zucks/config/poing_godot_admob_zucks.gd
@@ -48,5 +48,5 @@ func _get_android_dependencies(_platform: EditorExportPlatform, _debug: bool) ->
 
 func _get_android_dependencies_maven_repos(_platform: EditorExportPlatform, _debug: bool) -> PackedStringArray:
 	return PackedStringArray([
-		"https://raw.githubusercontent.com/zucks/ZucksAdNetworkSDK-Maven/master"
+		"https://raw.githubusercontent.com/zucks/ZucksAdNetworkSDK-Maven/admob-6.1.0.1"
 	])

--- a/platforms/android/src/mediation/zucks/config/poing_godot_admob_zucks.gd
+++ b/platforms/android/src/mediation/zucks/config/poing_godot_admob_zucks.gd
@@ -1,0 +1,52 @@
+# MIT License
+#
+# Copyright (c) 2026-present Poing Studios
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+extends EditorExportPlugin
+
+const PLUGIN_NAME := "zucks"
+var _dependency_library := [
+	"net.zucks:zucks-ad-network-sdk:6.1.0",
+	"net.zucks:zucks-ad-network-admob-adapter:6.1.0.1"
+]
+
+
+func _supports_platform(platform: EditorExportPlatform) -> bool:
+	return platform is EditorExportPlatformAndroid
+
+
+func _get_android_libraries(_platform: EditorExportPlatform, debug: bool) -> PackedStringArray:
+	var variant := "debug" if debug else "release"
+	var base := "res://addons/admob/android/bin/%s/libs" % PLUGIN_NAME
+
+	return PackedStringArray([
+		"%s/poing-godot-admob-%s-%s.aar" % [base, PLUGIN_NAME, variant]
+	])
+
+
+func _get_android_dependencies(_platform: EditorExportPlatform, _debug: bool) -> PackedStringArray:
+	return PackedStringArray(_dependency_library)
+
+
+func _get_android_dependencies_maven_repos(_platform: EditorExportPlatform, _debug: bool) -> PackedStringArray:
+	return PackedStringArray([
+		"https://raw.githubusercontent.com/zucks/ZucksAdNetworkSDK-Maven/master"
+	])

--- a/platforms/android/src/mediation/zucks/src/main/AndroidManifest.xml
+++ b/platforms/android/src/mediation/zucks/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/platforms/godot_editor/addons/admob/csharp/src/Mediation/Extras/LineAds/LineMediationExtras.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/Mediation/Extras/LineAds/LineMediationExtras.cs
@@ -31,12 +31,12 @@ namespace PoingStudios.AdMob.Mediation.Extras.LineAds
             set => Extras[ENABLE_AD_SOUND_KEY] = value;
         }
 
-        public override string GetAndroidMediationExtraClassName()
+        protected override string GetAndroidMediationExtraClassName()
         {
             return "com.poingstudios.godot.admob.mediation.line.LineExtrasBuilder";
         }
 
-        public override string GetIOSMediationExtraClassName()
+        protected override string GetIosMediationExtraClassName()
         {
             return "LinePoingExtrasBuilder";
         }

--- a/platforms/godot_editor/addons/admob/internal/exporters/android/export_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/exporters/android/export_plugin.gd
@@ -47,6 +47,7 @@ const MEDIATION_LIBS: Array[String] = [
 	"pangle",
 	"pubmatic",
 	"vpon",
+	"zucks",
 ]
 static var KNOWN_LIBS: Array[String] = ["ads"] + MEDIATION_LIBS
 

--- a/platforms/godot_editor/addons/admob/internal/exporters/ios/export_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/exporters/ios/export_plugin.gd
@@ -165,7 +165,7 @@ func _generate_package_swift(export_dir: String, dependencies: Array[Dictionary]
 			)
 
 	var content := (
-		'// swift-tools-version:5.9\nimport PackageDescription\n\nlet package = Package(\n    name: "PoingGodotAdMobDeps",\n    platforms: [.iOS(.v13)],\n    products: [\n        .library(\n            name: "PoingGodotAdMobDeps",\n            targets: ["PoingGodotAdMobDeps"]),\n    ],\n    dependencies: [\n'
+		'// swift-tools-version:5.9\nimport PackageDescription\n\nlet package = Package(\n    name: "PoingGodotAdMobDeps",\n    platforms: [.iOS(.v14)],\n    products: [\n        .library(\n            name: "PoingGodotAdMobDeps",\n            targets: ["PoingGodotAdMobDeps"]),\n    ],\n    dependencies: [\n'
 		+ package_deps_str
 		+ '    ],\n    targets: [\n        .target(\n            name: "PoingGodotAdMobDeps",\n            dependencies: [\n'
 		+ target_deps_str

--- a/platforms/godot_editor/addons/admob/internal/services/project_settings_service.gd
+++ b/platforms/godot_editor/addons/admob/internal/services/project_settings_service.gd
@@ -60,7 +60,8 @@ static func register_settings() -> void:
 		SettingDefinition.new(ANDROID_MEDIATION_PREFIX + "pubmatic", TYPE_BOOL, false),
 		SettingDefinition.new(ANDROID_MEDIATION_PREFIX + "vpon", TYPE_BOOL, false),
 		SettingDefinition.new(ANDROID_MEDIATION_PREFIX + "unity_ads", TYPE_BOOL, false),
-		SettingDefinition.new(ANDROID_MEDIATION_PREFIX + "vungle", TYPE_BOOL, false)
+		SettingDefinition.new(ANDROID_MEDIATION_PREFIX + "vungle", TYPE_BOOL, false),
+		SettingDefinition.new(ANDROID_MEDIATION_PREFIX + "zucks", TYPE_BOOL, false)
 	]
 
 	var active_names: Array[String] = []

--- a/platforms/godot_editor/project.godot
+++ b/platforms/godot_editor/project.godot
@@ -13,11 +13,22 @@ config_version=5
 android/mediation/applovin=true
 android/mediation/bidmachine=true
 android/mediation/chartboost=true
+android/mediation/dtexchange=true
+android/mediation/imobile=true
+android/mediation/inmobi=true
 android/mediation/ironsource=true
+android/mediation/line=true
 android/mediation/maio=true
 android/mediation/meta=true
+android/mediation/mintegral=true
+android/mediation/moloco=true
+android/mediation/mytarget=true
+android/mediation/pangle=true
+android/mediation/pubmatic=true
+android/mediation/vpon=true
 android/mediation/unity_ads=true
 android/mediation/vungle=true
+android/mediation/zucks=true
 
 [animation]
 

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -155,3 +155,4 @@ let package = Package(
         )
     ]
 )
+// cache_bust: 1

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -71,6 +71,22 @@ else:
 spm_artifacts = '.build/artifacts'
 env.Append(FRAMEWORKPATH=[spm_artifacts + '/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework/' + xcframework_directory])
 
+def get_spm_binary_target(artifact_folder, xcframework_name, zip_url):
+    for root, dirs, files in os.walk('.build', followlinks=True):
+        if root.endswith(xcframework_name):
+            return os.path.join(root, xcframework_directory)
+    print("WARNING: " + xcframework_name + " not found! Forcing manual download (SPM lazy-loads transitive binary targets)...")
+    import subprocess
+    target_dir = os.path.join('.build/artifacts', artifact_folder)
+    zip_path = os.path.join(target_dir, 'artifact.zip')
+    subprocess.call(['mkdir', '-p', target_dir])
+    subprocess.call(['curl', '-L', zip_url, '-o', zip_path])
+    subprocess.call(['unzip', '-q', '-o', zip_path, '-d', target_dir])
+    for root, dirs, files in os.walk(target_dir, followlinks=True):
+        if root.endswith(xcframework_name):
+            return os.path.join(root, xcframework_directory)
+    return ''
+
 if env['plugin'] == 'ads':
     env.Append(FRAMEWORKPATH=[spm_artifacts + '/swift-package-manager-google-user-messaging-platform/UserMessagingPlatform/UserMessagingPlatform.xcframework/' + xcframework_directory])
 elif env['plugin'] == 'meta':
@@ -108,7 +124,7 @@ elif env['plugin'] == 'chartboost':
     ])
 elif env['plugin'] == 'line':
     env.Append(FRAMEWORKPATH=[
-        spm_artifacts + '/googleads-mobile-ios-mediation-line/LineAdapter/LineAdapter.xcframework/' + xcframework_directory,
+        get_spm_binary_target('googleads-mobile-ios-mediation-line', 'LineAdapter.xcframework', 'https://dl.google.com/googleadmobadssdk/mediation/ios/line/LineAdapter-3.0.1.2.zip'),
         spm_artifacts + '/swift-package-manager-fivead/FiveAd/FiveAd.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'maio':
@@ -132,25 +148,9 @@ elif env['plugin'] == 'imobile':
         spm_artifacts + '/googleads-mobile-ios-mediation-imobile/IMobileSDK/ImobileSdkAds.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'dtexchange':
-    def get_iasdk_path():
-        for root, dirs, files in os.walk('.build', followlinks=True):
-            if root.endswith('IASDKCore.xcframework'):
-                return os.path.join(root, xcframework_directory)
-        
-        print("IASDKCore.xcframework not found! Forcing manual download (SPM lazy-loads transitive binary targets)...")
-        import subprocess
-        subprocess.call(['mkdir', '-p', '.build/artifacts/dtexchangesdk-ios-spm'])
-        subprocess.call(['curl', '-L', 'https://cdn2.inner-active.mobi/fmp-sdk/files/DTExchangeSDK-iOS-SPM-8.4.7.zip', '-o', '.build/artifacts/dtexchangesdk-ios-spm/iasdk.zip'])
-        subprocess.call(['unzip', '-q', '-o', '.build/artifacts/dtexchangesdk-ios-spm/iasdk.zip', '-d', '.build/artifacts/dtexchangesdk-ios-spm/'])
-        
-        for root, dirs, files in os.walk('.build/artifacts/dtexchangesdk-ios-spm', followlinks=True):
-            if root.endswith('IASDKCore.xcframework'):
-                return os.path.join(root, xcframework_directory)
-                
-        return ''
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,
-        get_iasdk_path()
+        get_spm_binary_target('dtexchangesdk-ios-spm', 'IASDKCore.xcframework', 'https://cdn2.inner-active.mobi/fmp-sdk/files/DTExchangeSDK-iOS-SPM-8.4.7.zip')
     ])
 elif env['plugin'] == 'mintegral':
     env.Append(FRAMEWORKPATH=[

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -71,21 +71,6 @@ else:
 spm_artifacts = '.build/artifacts'
 env.Append(FRAMEWORKPATH=[spm_artifacts + '/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework/' + xcframework_directory])
 
-def get_spm_binary_target(artifact_folder, xcframework_name, zip_url):
-    for root, dirs, files in os.walk('.build', followlinks=True):
-        if root.endswith(xcframework_name):
-            return os.path.join(root, xcframework_directory)
-    print("WARNING: " + xcframework_name + " not found! Forcing manual download (SPM lazy-loads transitive binary targets)...")
-    import subprocess
-    target_dir = os.path.join('.build/artifacts', artifact_folder)
-    zip_path = os.path.join(target_dir, 'artifact.zip')
-    subprocess.call(['mkdir', '-p', target_dir])
-    subprocess.call(['curl', '-L', zip_url, '-o', zip_path])
-    subprocess.call(['unzip', '-q', '-o', zip_path, '-d', target_dir])
-    for root, dirs, files in os.walk(target_dir, followlinks=True):
-        if root.endswith(xcframework_name):
-            return os.path.join(root, xcframework_directory)
-    return ''
 
 if env['plugin'] == 'ads':
     env.Append(FRAMEWORKPATH=[spm_artifacts + '/swift-package-manager-google-user-messaging-platform/UserMessagingPlatform/UserMessagingPlatform.xcframework/' + xcframework_directory])
@@ -124,7 +109,7 @@ elif env['plugin'] == 'chartboost':
     ])
 elif env['plugin'] == 'line':
     env.Append(FRAMEWORKPATH=[
-        get_spm_binary_target('googleads-mobile-ios-mediation-line', 'LineAdapter.xcframework', 'https://dl.google.com/googleadmobadssdk/mediation/ios/line/LineAdapter-3.0.1.2.zip'),
+        spm_artifacts + '/googleads-mobile-ios-mediation-line/LineAdapter/LineAdapter.xcframework/' + xcframework_directory,
         spm_artifacts + '/swift-package-manager-fivead/FiveAd/FiveAd.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'maio':
@@ -150,7 +135,7 @@ elif env['plugin'] == 'imobile':
 elif env['plugin'] == 'dtexchange':
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,
-        get_spm_binary_target('dtexchangesdk-ios-spm', 'IASDKCore.xcframework', 'https://cdn2.inner-active.mobi/fmp-sdk/files/DTExchangeSDK-iOS-SPM-8.4.7.zip')
+        spm_artifacts + '/dtexchangesdk-ios-spm/IASDKCore/IASDKCore.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'mintegral':
     env.Append(FRAMEWORKPATH=[

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -2,7 +2,6 @@
 import os
 import sys
 import subprocess
-import glob
 
 if sys.version_info < (3,):
     def decode_utf8(x):
@@ -12,12 +11,7 @@ else:
     def decode_utf8(x):
         return codecs.utf_8_decode(x)[0]
 
-def find_framework_path(spm_artifacts, pattern, xcframework_directory):
-    search_pattern = os.path.join(spm_artifacts, pattern)
-    matches = glob.glob(search_pattern, recursive=True)
-    if matches:
-        return os.path.join(matches[0], xcframework_directory)
-    return os.path.join(spm_artifacts, pattern.replace('**/', ''), xcframework_directory)
+
 
 # Most of the settings are taken from https://github.com/BastiaanOlij/gdnative_cpp_example
 
@@ -140,7 +134,7 @@ elif env['plugin'] == 'imobile':
 elif env['plugin'] == 'dtexchange':
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,
-        find_framework_path(spm_artifacts, '**/IASDKCore.xcframework', xcframework_directory)
+        spm_artifacts + '/dtexchangesdk-ios-spm/IASDKCore/IASDKCore.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'mintegral':
     env.Append(FRAMEWORKPATH=[

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+import glob
 
 if sys.version_info < (3,):
     def decode_utf8(x):
@@ -10,6 +11,13 @@ else:
     import codecs
     def decode_utf8(x):
         return codecs.utf_8_decode(x)[0]
+
+def find_framework_path(spm_artifacts, pattern, xcframework_directory):
+    search_pattern = os.path.join(spm_artifacts, pattern)
+    matches = glob.glob(search_pattern, recursive=True)
+    if matches:
+        return os.path.join(matches[0], xcframework_directory)
+    return os.path.join(spm_artifacts, pattern.replace('**/', ''), xcframework_directory)
 
 # Most of the settings are taken from https://github.com/BastiaanOlij/gdnative_cpp_example
 
@@ -132,7 +140,7 @@ elif env['plugin'] == 'imobile':
 elif env['plugin'] == 'dtexchange':
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,
-        spm_artifacts + '/dtexchangesdk-ios-spm/IASDKCore/IASDKCore.xcframework/' + xcframework_directory
+        find_framework_path(spm_artifacts, '**/IASDKCore.xcframework', xcframework_directory)
     ])
 elif env['plugin'] == 'mintegral':
     env.Append(FRAMEWORKPATH=[

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -133,9 +133,13 @@ elif env['plugin'] == 'imobile':
     ])
 elif env['plugin'] == 'dtexchange':
     def get_iasdk_path():
-        for root, dirs, files in os.walk(spm_artifacts):
+        found = []
+        for root, dirs, files in os.walk('.build', followlinks=True):
+            if root.endswith('.xcframework'):
+                found.append(root)
             if root.endswith('IASDKCore.xcframework'):
                 return os.path.join(root, xcframework_directory)
+        print("DEBUG XCFRAMEWORKS FOUND: ", found)
         return ''
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -132,7 +132,7 @@ elif env['plugin'] == 'imobile':
 elif env['plugin'] == 'dtexchange':
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,
-        spm_artifacts + '/DTExchangeSDK-iOS-SPM/IASDKCore/IASDKCore.xcframework/' + xcframework_directory
+        spm_artifacts + '/dtexchangesdk-ios-spm/IASDKCore/IASDKCore.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'mintegral':
     env.Append(FRAMEWORKPATH=[

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -132,9 +132,14 @@ elif env['plugin'] == 'imobile':
         spm_artifacts + '/googleads-mobile-ios-mediation-imobile/IMobileSDK/ImobileSdkAds.xcframework/' + xcframework_directory
     ])
 elif env['plugin'] == 'dtexchange':
+    def get_iasdk_path():
+        for root, dirs, files in os.walk(spm_artifacts):
+            if root.endswith('IASDKCore.xcframework'):
+                return os.path.join(root, xcframework_directory)
+        return ''
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,
-        spm_artifacts + '/dtexchangesdk-ios-spm/IASDKCore/IASDKCore.xcframework/' + xcframework_directory
+        get_iasdk_path()
     ])
 elif env['plugin'] == 'mintegral':
     env.Append(FRAMEWORKPATH=[

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -133,13 +133,20 @@ elif env['plugin'] == 'imobile':
     ])
 elif env['plugin'] == 'dtexchange':
     def get_iasdk_path():
-        found = []
         for root, dirs, files in os.walk('.build', followlinks=True):
-            if root.endswith('.xcframework'):
-                found.append(root)
             if root.endswith('IASDKCore.xcframework'):
                 return os.path.join(root, xcframework_directory)
-        print("DEBUG XCFRAMEWORKS FOUND: ", found)
+        
+        print("IASDKCore.xcframework not found! Forcing manual download (SPM lazy-loads transitive binary targets)...")
+        import subprocess
+        subprocess.call(['mkdir', '-p', '.build/artifacts/dtexchangesdk-ios-spm'])
+        subprocess.call(['curl', '-L', 'https://cdn2.inner-active.mobi/fmp-sdk/files/DTExchangeSDK-iOS-SPM-8.4.7.zip', '-o', '.build/artifacts/dtexchangesdk-ios-spm/iasdk.zip'])
+        subprocess.call(['unzip', '-q', '-o', '.build/artifacts/dtexchangesdk-ios-spm/iasdk.zip', '-d', '.build/artifacts/dtexchangesdk-ios-spm/'])
+        
+        for root, dirs, files in os.walk('.build/artifacts/dtexchangesdk-ios-spm', followlinks=True):
+            if root.endswith('IASDKCore.xcframework'):
+                return os.path.join(root, xcframework_directory)
+                
         return ''
     env.Append(FRAMEWORKPATH=[
         spm_artifacts + '/googleads-mobile-ios-mediation-dtexchange/DTExchangeAdapter/DTExchangeAdapter.xcframework/' + xcframework_directory,

--- a/platforms/ios/scripts/build.sh
+++ b/platforms/ios/scripts/build.sh
@@ -119,9 +119,9 @@ ensure_dir "$RELEASE_DIR"
 ensure_dir "./bin/static_libraries"
 ensure_dir "./bin/xcframeworks"
 
-if [ ! -d "$SPM_BUILD_DIR" ]; then
-    ./scripts/lib/resolve_spm_deps.sh || exit 1
-fi
+# Always resolve SPM dependencies to ensure all binary targets (even lazy-loaded ones) are present,
+# especially when restoring the .build folder from CI cache.
+./scripts/lib/resolve_spm_deps.sh || exit 1
 
 # --- INTERNAL BUILD ---
 log_info "--- Building Internal Plugin ---"

--- a/platforms/ios/scripts/lib/resolve_spm_deps.sh
+++ b/platforms/ios/scripts/lib/resolve_spm_deps.sh
@@ -35,11 +35,11 @@ fi
 
 log_info "Resolving Swift Package Manager dependencies..."
 
-if swift package resolve; then
+if swift build; then
     SPM_BUILD_DIR="$(pwd)/.build"
     export SPM_BUILD_DIR
-    log_success "SPM dependencies resolved at: $SPM_BUILD_DIR"
+    log_success "SPM dependencies resolved and built at: $SPM_BUILD_DIR"
 else
-    log_error "Failed to resolve SPM dependencies."
+    log_error "Failed to build SPM dependencies."
     exit 1
 fi

--- a/platforms/ios/src/mediation/dtexchange/config/poing-godot-admob-dtexchange.gdip
+++ b/platforms/ios/src/mediation/dtexchange/config/poing-godot-admob-dtexchange.gdip
@@ -13,7 +13,8 @@ capabilities=[]
 files=[]
 linker_flags=[]
 admob_packages=[
-    "https://github.com/googleads/googleads-mobile-ios-mediation-dtexchange.git@exact:8.4.701|DTExchangeAdapterTarget"
+    "https://github.com/googleads/googleads-mobile-ios-mediation-dtexchange.git@exact:8.4.701|DTExchangeAdapterTarget",
+    "https://github.com/inner-active/DTExchangeSDK-iOS-SPM.git@exact:8.4.7|DTExchangeSDKTarget"
 ]
 
 [plist]

--- a/platforms/ios/src/mediation/dtexchange/config/poing-godot-admob-dtexchange.gdip
+++ b/platforms/ios/src/mediation/dtexchange/config/poing-godot-admob-dtexchange.gdip
@@ -1,6 +1,6 @@
 [config]
 name="AdMob DT Exchange"
-binary="libpoing-godot-admob-dtexchange.a"
+binary="poing-godot-admob/bin/poing-godot-admob-dtexchange.xcframework"
 
 initialization="register_poing_godot_admob_dtexchange_types"
 deinitialization="unregister_poing_godot_admob_dtexchange_types"

--- a/platforms/ios/src/mediation/dtexchange/config/poing-godot-admob-dtexchange.gdip
+++ b/platforms/ios/src/mediation/dtexchange/config/poing-godot-admob-dtexchange.gdip
@@ -13,8 +13,7 @@ capabilities=[]
 files=[]
 linker_flags=[]
 admob_packages=[
-    "https://github.com/googleads/googleads-mobile-ios-mediation-dtexchange.git@exact:8.4.701|DTExchangeAdapterTarget",
-    "https://github.com/inner-active/DTExchangeSDK-iOS-SPM.git@exact:8.4.7|DTExchangeSDKTarget"
+    "https://github.com/googleads/googleads-mobile-ios-mediation-dtexchange.git@exact:8.4.701|DTExchangeAdapterTarget"
 ]
 
 [plist]

--- a/platforms/ios/src/mediation/imobile/config/poing-godot-admob-imobile.gdip
+++ b/platforms/ios/src/mediation/imobile/config/poing-godot-admob-imobile.gdip
@@ -12,7 +12,7 @@ capabilities=[]
 files=[]
 linker_flags=[]
 admob_packages=[
-    "https://github.com/googleads/googleads-mobile-ios-mediation-imobile.git@exact:2.3.407|iMobileAdapterTarget"
+    "https://github.com/googleads/googleads-mobile-ios-mediation-imobile.git@exact:2.3.407|IMobileAdapterTarget"
 ]
 
 [plist]

--- a/platforms/ios/src/mediation/imobile/config/poing-godot-admob-imobile.gdip
+++ b/platforms/ios/src/mediation/imobile/config/poing-godot-admob-imobile.gdip
@@ -1,6 +1,6 @@
 [config]
 name="AdMob iMobile"
-binary="libpoing-godot-admob-imobile.a"
+binary="poing-godot-admob/bin/poing-godot-admob-imobile.xcframework"
 initialization="register_poing_godot_admob_imobile_types"
 deinitialization="unregister_poing_godot_admob_imobile_types"
 


### PR DESCRIPTION
This PR implements Zucks Mediation for Android, cleans up empty iOS mediation wrappers (Zucks/Vpon) since they must be integrated manually in Xcode, and fixes configuration paths for DT Exchange and iMobile iOS plugins.

### Changes:
- **Zucks Android support**: Configured Maven dependency coordinates and export script for automatic gradle resolution.
- **iOS cleanup**: Removed empty wrapper classes and `.gdip` files for Zucks and Vpon since they don't support SPM (documented manual integration steps in `zucks.md` and `vpon.md`).
- **iOS configuration fixes**: Updated `poing-godot-admob-dtexchange.gdip` and `poing-godot-admob-imobile.gdip` from `.a` libraries to `.xcframework` paths.