### PR TITLE
fix: SafeArea not working correctly on sample with mock ads

### DIFF
--- a/platforms/godot_editor/addons/admob/csharp/sample/SafeArea.cs
+++ b/platforms/godot_editor/addons/admob/csharp/sample/SafeArea.cs
@@ -27,8 +27,7 @@ using PoingStudios.AdMob.Sample;
 
 public partial class SafeArea : MarginContainer
 {
-	private float _ad_margin_top = 0.0f;
-	private float _ad_margin_bottom = 0.0f;
+	private AdView _activeAdView = null;
 
 	public override void _Ready()
 	{
@@ -39,33 +38,13 @@ public partial class SafeArea : MarginContainer
 
 	public void UpdateAdOverlap(AdView adView)
 	{
-		ResetAdOverlap();
-
-		if (adView == null)
-		{
-			return;
-		}
-
-		var pos = adView.Position.Value;
-		var height = (float)adView.GetHeightInPixels();
-
-		// Mapping AdPosition enum values to top/bottom margins
-		if (pos == AdPosition.Values.Top || pos == AdPosition.Values.TopLeft || pos == AdPosition.Values.TopRight)
-		{
-			_ad_margin_top = height;
-		}
-		else if (pos == AdPosition.Values.Bottom || pos == AdPosition.Values.BottomLeft || pos == AdPosition.Values.BottomRight)
-		{
-			_ad_margin_bottom = height;
-		}
-
+		_activeAdView = adView;
 		UpdateSafeArea();
 	}
 
 	public void ResetAdOverlap()
 	{
-		_ad_margin_top = 0.0f;
-		_ad_margin_bottom = 0.0f;
+		_activeAdView = null;
 		UpdateSafeArea();
 	}
 
@@ -92,6 +71,23 @@ public partial class SafeArea : MarginContainer
 			scaleFactor = 1.0f;
 		}
 
+		float adMarginTop = 0f;
+		float adMarginBottom = 0f;
+
+		if (_activeAdView != null)
+		{
+			var pos = _activeAdView.Position.Value;
+			var height = (float)_activeAdView.GetHeightInPixels();
+			if (pos == AdPosition.Values.Top || pos == AdPosition.Values.TopLeft || pos == AdPosition.Values.TopRight)
+			{
+				adMarginTop = height;
+			}
+			else if (pos == AdPosition.Values.Bottom || pos == AdPosition.Values.BottomLeft || pos == AdPosition.Values.BottomRight)
+			{
+				adMarginBottom = height;
+			}
+		}
+
 		// DisplayServer returns physical screen coordinates for the safe area
 		var safeTop = 0f;
 		var safeLeft = 0f;
@@ -108,9 +104,9 @@ public partial class SafeArea : MarginContainer
 
 		// Apply final margins scaled to the viewport
 		ApplyMargins(
-			Mathf.Max(0f, (safeTop + _ad_margin_top) * scaleFactor),
+			Mathf.Max(0f, (safeTop + adMarginTop) * scaleFactor),
 			Mathf.Max(0f, safeLeft * scaleFactor),
-			Mathf.Max(0f, (safeBottom + _ad_margin_bottom) * scaleFactor),
+			Mathf.Max(0f, (safeBottom + adMarginBottom) * scaleFactor),
 			Mathf.Max(0f, safeRight * scaleFactor)
 		);
 	}

--- a/platforms/godot_editor/addons/admob/csharp/src/mock/MockAdViewPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/mock/MockAdViewPlugin.cs
@@ -74,16 +74,9 @@ namespace PoingStudios.AdMob.Core
 
 			var ui = new ColorRect
 			{
-				Color = Colors.DarkGray
+				Color = Colors.White
 			};
 			ui.Hide();
-
-			var bg_color = new ColorRect
-			{
-				Color = Colors.White,
-			};
-			bg_color.SetAnchorsPreset(Control.LayoutPreset.FullRect);
-			ui.AddChild(bg_color);
 
 			Godot.Collections.Dictionary adSize = adViewDictionary.TryGetValue("ad_size", out var sizeVar) 
 				? sizeVar.AsGodotDictionary()
@@ -362,7 +355,7 @@ namespace PoingStudios.AdMob.Core
 			var children = ad.Ui.GetChildren();
 			foreach (var child in children)
 			{
-				if (child is ColorRect || child == ad.ToggleBtn || child == ad.CloseBtn) continue;
+				if (child == ad.ToggleBtn || child == ad.CloseBtn) continue;
 				child.QueueFree();
 			}
 
@@ -452,10 +445,11 @@ namespace PoingStudios.AdMob.Core
 				hbox.AddChild(spacer2);
 
 				var admobLogo = new TextureRect { Texture = ResourceLoader.Load<Texture2D>("res://addons/admob/assets/icon-120.png"), ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize, StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered, CustomMinimumSize = new Vector2(30 * scaleFactor, 30 * scaleFactor) };
+				admobLogo.SizeFlagsHorizontal = Control.SizeFlags.ShrinkCenter;
 				admobLogo.SizeFlagsVertical = Control.SizeFlags.ShrinkCenter;
 				
 				var rightMargin = new MarginContainer();
-				rightMargin.AddThemeConstantOverride("margin_right", (int)Mathf.Round(15 * scaleFactor));
+				rightMargin.AddThemeConstantOverride("margin_right", (int)Mathf.Round(45 * scaleFactor));
 				rightMargin.AddChild(admobLogo);
 				hbox.AddChild(rightMargin);
 			}
@@ -554,15 +548,49 @@ namespace PoingStudios.AdMob.Core
 		public int get_width_in_pixels(int uid)
 		{
 			if (!_ads.TryGetValue(uid, out AdData ad)) return 0;
-			float screenScale = DisplayServer.ScreenGetScale(DisplayServer.WindowGetCurrentScreen());
-			return (int)(get_width(uid) * screenScale);
+			if (ad.IsHidden) return 0;
+
+			var viewportSize = GetViewport().GetVisibleRect().Size;
+			var windowSize = DisplayServer.WindowGetSize();
+			float guiScaleFactor = 1.0f;
+			if (windowSize.Y > 0)
+			{
+				guiScaleFactor = viewportSize.Y / (float)windowSize.Y;
+			}
+
+			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360f;
+			if (scaleFactor <= 0.0f)
+			{
+				scaleFactor = 1.0f;
+			}
+
+			float widthInViewport = ad.IsAdaptive ? viewportSize.X : ad.Width * scaleFactor;
+			return (int)Mathf.Round(widthInViewport / guiScaleFactor);
 		}
 
 		public int get_height_in_pixels(int uid)
 		{
 			if (!_ads.TryGetValue(uid, out AdData ad)) return 0;
-			float screenScale = DisplayServer.ScreenGetScale(DisplayServer.WindowGetCurrentScreen());
-			return (int)(get_height(uid) * screenScale);
+			if (ad.IsHidden) return 0;
+
+			var viewportSize = GetViewport().GetVisibleRect().Size;
+			var windowSize = DisplayServer.WindowGetSize();
+			float guiScaleFactor = 1.0f;
+			if (windowSize.Y > 0)
+			{
+				guiScaleFactor = viewportSize.Y / (float)windowSize.Y;
+			}
+
+			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360f;
+			if (scaleFactor <= 0.0f)
+			{
+				scaleFactor = 1.0f;
+			}
+
+			bool isExpanded = ad.IsCollapsible && !ad.IsCollapsed;
+			int heightDp = isExpanded ? 250 : ad.Height;
+			float heightInViewport = heightDp * scaleFactor;
+			return (int)Mathf.Round(heightInViewport / guiScaleFactor);
 		}
 
 		public bool is_collapsible(int uid) => _ads.TryGetValue(uid, out AdData ad) && ad.IsCollapsible;

--- a/platforms/godot_editor/addons/admob/csharp/src/mock/MockAppOpenAdPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/mock/MockAppOpenAdPlugin.cs
@@ -113,7 +113,7 @@ namespace PoingStudios.AdMob.Core
 			viewportSize.X = Mathf.Max(1f, viewportSize.X);
 			viewportSize.Y = Mathf.Max(1f, viewportSize.Y);
 
-			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360f;
+			float scaleFactor = Mathf.Min(viewportSize.X / 360f, viewportSize.Y / 640f);
 			if (scaleFactor <= 0.0f)
 			{
 				scaleFactor = 1.0f;

--- a/platforms/godot_editor/addons/admob/csharp/src/mock/MockInterstitialAdPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/mock/MockInterstitialAdPlugin.cs
@@ -117,7 +117,7 @@ namespace PoingStudios.AdMob.Core
 			viewportSize.X = Mathf.Max(1f, viewportSize.X);
 			viewportSize.Y = Mathf.Max(1f, viewportSize.Y);
 
-			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360.0f;
+			float scaleFactor = Mathf.Min(viewportSize.X / 360f, viewportSize.Y / 640f);
 			if (scaleFactor <= 0.0f)
 			{
 				scaleFactor = 1.0f;

--- a/platforms/godot_editor/addons/admob/csharp/src/mock/MockNativeOverlayAdPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/mock/MockNativeOverlayAdPlugin.cs
@@ -219,7 +219,7 @@ namespace PoingStudios.AdMob.Core
 			viewportSize.X = Mathf.Max(1f, viewportSize.X);
 			viewportSize.Y = Mathf.Max(1f, viewportSize.Y);
 
-			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360f;
+			float scaleFactor = Mathf.Min(viewportSize.X / 360f, viewportSize.Y / 640f);
 			if (scaleFactor <= 0.0f)
 			{
 				scaleFactor = 1.0f;

--- a/platforms/godot_editor/addons/admob/csharp/src/mock/MockRewardedAdPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/mock/MockRewardedAdPlugin.cs
@@ -239,7 +239,7 @@ namespace PoingStudios.AdMob.Core
 			viewportSize.X = Mathf.Max(1f, viewportSize.X);
 			viewportSize.Y = Mathf.Max(1f, viewportSize.Y);
 
-			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360.0f;
+			float scaleFactor = Mathf.Min(viewportSize.X / 360f, viewportSize.Y / 640f);
 			if (scaleFactor <= 0.0f)
 			{
 				scaleFactor = 1.0f;

--- a/platforms/godot_editor/addons/admob/csharp/src/mock/MockRewardedInterstitialAdPlugin.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/mock/MockRewardedInterstitialAdPlugin.cs
@@ -239,7 +239,7 @@ namespace PoingStudios.AdMob.Core
 			viewportSize.X = Mathf.Max(1f, viewportSize.X);
 			viewportSize.Y = Mathf.Max(1f, viewportSize.Y);
 
-			float scaleFactor = Mathf.Min(viewportSize.X, viewportSize.Y) / 360.0f;
+			float scaleFactor = Mathf.Min(viewportSize.X / 360f, viewportSize.Y / 640f);
 			if (scaleFactor <= 0.0f)
 			{
 				scaleFactor = 1.0f;

--- a/platforms/godot_editor/addons/admob/gdscript/sample/SafeArea.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/sample/SafeArea.gd
@@ -24,8 +24,7 @@ extends MarginContainer
 
 const Registry = preload("res://addons/admob/internal/sample_registry.gd")
 
-var _ad_margin_top := 0.0
-var _ad_margin_bottom := 0.0
+var _active_ad_view: AdView = null
 
 
 func _ready() -> void:
@@ -35,32 +34,12 @@ func _ready() -> void:
 
 
 func update_ad_overlap(ad_view: AdView) -> void:
-	reset_ad_overlap()
-
-	if not ad_view:
-		return
-
-	var pos := ad_view.ad_position
-	var height := float(ad_view.get_height_in_pixels())
-
-	# Mapping AdPosition enum values to top/bottom margins
-	if (
-		pos.value
-		in [AdPosition.Values.TOP, AdPosition.Values.TOP_LEFT, AdPosition.Values.TOP_RIGHT]
-	):
-		_ad_margin_top = height
-	elif (
-		pos.value
-		in [AdPosition.Values.BOTTOM, AdPosition.Values.BOTTOM_LEFT, AdPosition.Values.BOTTOM_RIGHT]
-	):
-		_ad_margin_bottom = height
-
+	_active_ad_view = ad_view
 	_update_safe_area()
 
 
 func reset_ad_overlap() -> void:
-	_ad_margin_top = 0.0
-	_ad_margin_bottom = 0.0
+	_active_ad_view = null
 	_update_safe_area()
 
 
@@ -81,6 +60,23 @@ func _update_safe_area() -> void:
 	if is_nan(scale_factor) or is_inf(scale_factor) or scale_factor <= 0.0:
 		scale_factor = 1.0
 
+	var ad_margin_top := 0.0
+	var ad_margin_bottom := 0.0
+
+	if _active_ad_view and is_instance_valid(_active_ad_view):
+		var pos := _active_ad_view.ad_position
+		var height := float(_active_ad_view.get_height_in_pixels())
+		if (
+			pos.value
+			in [AdPosition.Values.TOP, AdPosition.Values.TOP_LEFT, AdPosition.Values.TOP_RIGHT]
+		):
+			ad_margin_top = height
+		elif (
+			pos.value
+			in [AdPosition.Values.BOTTOM, AdPosition.Values.BOTTOM_LEFT, AdPosition.Values.BOTTOM_RIGHT]
+		):
+			ad_margin_bottom = height
+
 	# DisplayServer returns physical screen coordinates for the safe area
 	var safe_top := 0.0
 	var safe_left := 0.0
@@ -95,9 +91,9 @@ func _update_safe_area() -> void:
 
 	# Apply final margins scaled to the viewport
 	_apply_margins(
-		max(0.0, (safe_top + _ad_margin_top) * scale_factor),
+		max(0.0, (safe_top + ad_margin_top) * scale_factor),
 		max(0.0, safe_left * scale_factor),
-		max(0.0, (safe_bottom + _ad_margin_bottom) * scale_factor),
+		max(0.0, (safe_bottom + ad_margin_bottom) * scale_factor),
 		max(0.0, safe_right * scale_factor)
 	)
 

--- a/platforms/godot_editor/addons/admob/internal/mock/mock_ad_view_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/mock/mock_ad_view_plugin.gd
@@ -45,13 +45,8 @@ func create(ad_view_dictionary: Dictionary) -> int:
 	var uid := _uid_counter
 
 	var ui := ColorRect.new()
-	ui.color = Color.DARK_GRAY
+	ui.color = Color.WHITE
 	ui.hide()
-
-	var bg_color := ColorRect.new()
-	bg_color.color = Color.WHITE
-	bg_color.set_anchors_preset(Control.PRESET_FULL_RECT)
-	ui.add_child(bg_color)
 
 	var ad_size: Dictionary = ad_view_dictionary.get("ad_size", {"width": 320, "height": 50})
 	var width: int = ad_size.get("width", 320)
@@ -194,13 +189,39 @@ func get_height(uid: int) -> int:
 
 func get_width_in_pixels(uid: int) -> int:
 	if not _ads.has(uid): return 0
-	var screen_scale := DisplayServer.screen_get_scale(DisplayServer.window_get_current_screen())
-	return int(get_width(uid) * screen_scale)
+	var is_hidden: bool = _ads[uid].get("is_hidden", false)
+	if is_hidden:
+		return 0
+	var viewport_size := get_viewport().get_visible_rect().size
+	var window_size := DisplayServer.window_get_size()
+	var gui_scale_factor := 1.0
+	if window_size.y > 0:
+		gui_scale_factor = viewport_size.y / float(window_size.y)
+	var is_adaptive: bool = _ads[uid].get("is_adaptive", false)
+	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	if scale_factor <= 0.0:
+		scale_factor = 1.0
+	var width_in_viewport = viewport_size.x if is_adaptive else _ads[uid]["width"] * scale_factor
+	return int(round(width_in_viewport / gui_scale_factor))
 
 func get_height_in_pixels(uid: int) -> int:
 	if not _ads.has(uid): return 0
-	var screen_scale := DisplayServer.screen_get_scale(DisplayServer.window_get_current_screen())
-	return int(get_height(uid) * screen_scale)
+	var is_hidden: bool = _ads[uid].get("is_hidden", false)
+	if is_hidden:
+		return 0
+	var viewport_size := get_viewport().get_visible_rect().size
+	var window_size := DisplayServer.window_get_size()
+	var gui_scale_factor := 1.0
+	if window_size.y > 0:
+		gui_scale_factor = viewport_size.y / float(window_size.y)
+
+	var is_expanded: bool = _ads[uid].get("is_collapsible", false) and not _ads[uid].get("is_collapsed", false)
+	var height_dp: int = 250 if is_expanded else _ads[uid]["height"]
+	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	if scale_factor <= 0.0:
+		scale_factor = 1.0
+	var height_in_viewport = height_dp * scale_factor
+	return int(round(height_in_viewport / gui_scale_factor))
 
 func is_collapsible(uid: int) -> bool:
 	return _ads[uid].get("is_collapsible", false) if _ads.has(uid) else false
@@ -336,7 +357,7 @@ func _update_size(uid: int) -> void:
 		btn.add_theme_font_size_override("font_size", max(1, int(round(14 * scale_factor))))
 
 	for child in ad["ui"].get_children():
-		if child is ColorRect or child == ad.get("toggle_btn") or child == ad.get("close_btn"): continue
+		if child == ad.get("toggle_btn") or child == ad.get("close_btn"): continue
 		child.queue_free()
 
 
@@ -454,10 +475,11 @@ func _update_size(uid: int) -> void:
 		admob_logo.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 		admob_logo.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 		admob_logo.custom_minimum_size = Vector2(30 * scale_factor, 30 * scale_factor)
+		admob_logo.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 		admob_logo.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 
 		var right_margin := MarginContainer.new()
-		right_margin.add_theme_constant_override("margin_right", int(round(15 * scale_factor)))
+		right_margin.add_theme_constant_override("margin_right", int(round(45 * scale_factor)))
 		right_margin.add_child(admob_logo)
 		hbox.add_child(right_margin)
 

--- a/platforms/godot_editor/addons/admob/internal/mock/mock_app_open_ad_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/mock/mock_app_open_ad_plugin.gd
@@ -98,7 +98,7 @@ func _update_ui(uid: int) -> void:
 	viewport_size.x = max(1.0, viewport_size.x)
 	viewport_size.y = max(1.0, viewport_size.y)
 
-	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	var scale_factor: float = min(viewport_size.x / 360.0, viewport_size.y / 640.0)
 	if scale_factor <= 0.0:
 		scale_factor = 1.0
 

--- a/platforms/godot_editor/addons/admob/internal/mock/mock_interstitial_ad_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/mock/mock_interstitial_ad_plugin.gd
@@ -98,7 +98,7 @@ func _update_ui(uid: int) -> void:
 	viewport_size.x = max(1.0, viewport_size.x)
 	viewport_size.y = max(1.0, viewport_size.y)
 
-	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	var scale_factor: float = min(viewport_size.x / 360.0, viewport_size.y / 640.0)
 	if scale_factor <= 0.0:
 		scale_factor = 1.0
 

--- a/platforms/godot_editor/addons/admob/internal/mock/mock_native_overlay_ad_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/mock/mock_native_overlay_ad_plugin.gd
@@ -167,7 +167,7 @@ func _update_ui_position(uid: int) -> void:
 	viewport_size.x = max(1.0, viewport_size.x)
 	viewport_size.y = max(1.0, viewport_size.y)
 
-	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	var scale_factor: float = min(viewport_size.x / 360.0, viewport_size.y / 640.0)
 	if scale_factor <= 0.0:
 		scale_factor = 1.0
 

--- a/platforms/godot_editor/addons/admob/internal/mock/mock_rewarded_ad_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/mock/mock_rewarded_ad_plugin.gd
@@ -180,7 +180,7 @@ func _update_ui(uid: int) -> void:
 	viewport_size.x = max(1.0, viewport_size.x)
 	viewport_size.y = max(1.0, viewport_size.y)
 
-	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	var scale_factor: float = min(viewport_size.x / 360.0, viewport_size.y / 640.0)
 	if scale_factor <= 0.0:
 		scale_factor = 1.0
 

--- a/platforms/godot_editor/addons/admob/internal/mock/mock_rewarded_interstitial_ad_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/mock/mock_rewarded_interstitial_ad_plugin.gd
@@ -180,7 +180,7 @@ func _update_ui(uid: int) -> void:
 	viewport_size.x = max(1.0, viewport_size.x)
 	viewport_size.y = max(1.0, viewport_size.y)
 
-	var scale_factor: float = min(viewport_size.x, viewport_size.y) / 360.0
+	var scale_factor: float = min(viewport_size.x / 360.0, viewport_size.y / 640.0)
 	if scale_factor <= 0.0:
 		scale_factor = 1.0
 


### PR DESCRIPTION
## Summary

This PR fixes the SafeArea layout issues in the sample scenes when using mock ads. The SafeArea margins were not being calculated correctly, causing UI elements to overlap or not respect device safe areas.

## Changes

- Refactored SafeArea margin logic in both GDScript and C# samples to use the active AdView reference instead of cached fields
- Improved mock ad scale factor logic and SafeArea calculations for consistency across platforms
- Updated all mock ad plugins (AdView, AppOpen, Interstitial, NativeOverlay, Rewarded, RewardedInterstitial) to provide proper sizing information for mock ads

## Testing

- Verified sample scenes render correctly with mock ads on different screen sizes
- Confirmed SafeArea margins are properly applied when using real AdMob ads