### PR TITLE
ci: restrict documentation deploy to tag pushes only

### DIFF
--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -1,8 +1,6 @@
 name: "[CD] Deploy Documentation (v1)"
 on:
   push:
-    branches:
-      - v1
     tags:
       - 'v*-godot3'
 
@@ -30,16 +28,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Deploy documentation
         run: |
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            # Extract version from plugin.cfg (e.g. 1.3)
-            BASE_VERSION=$(grep "version=" platforms/godot_editor/addons/admob/plugin.cfg | cut -d'"' -f2)
-            CLEAN_VERSION=$(echo "$BASE_VERSION" | sed 's/^v//')
-            VERSION=$(echo "$CLEAN_VERSION" | cut -d. -f1,2)
-            VERSION_TAG="${VERSION}-godot3"
-            
-            # Deploy versioned folder and update general alias 'v1'
-            mike deploy --push --update-aliases $VERSION_TAG v1
-          else
-            # Deploy to 'latest-godot3' for direct pushes to v1 branch
-            mike deploy --push --update-aliases latest-godot3
-          fi
+          # Extract version from plugin.cfg (e.g. 1.3)
+          BASE_VERSION=$(grep "version=" platforms/godot_editor/addons/admob/plugin.cfg | cut -d'"' -f2)
+          CLEAN_VERSION=$(echo "$BASE_VERSION" | sed 's/^v//')
+          VERSION=$(echo "$CLEAN_VERSION" | cut -d. -f1,2)
+          
+          # Delete obsolete/incorrect versions from gh-pages if they exist
+          mike delete latest-godot3 1.3-godot3 --push || true
+          
+          # Deploy versioned folder (e.g. 1.3)
+          mike deploy --push --update-aliases $VERSION


### PR DESCRIPTION
This PR updates the documentation deployment workflow to trigger only on tags matching 'v*-godot3', and to deploy to the version derived from plugin.cfg (e.g. 1.3). It also deletes the obsolete 'latest-godot3' and '1.3-godot3' releases from gh-pages.