### PR TITLE
ci: work around gh CLI bug setting latest release

### DIFF
--- a/.github/workflows/cd-build-and-release.yml
+++ b/.github/workflows/cd-build-and-release.yml
@@ -248,6 +248,7 @@ jobs:
         VERSION: ${{ needs.initialize.outputs.version }}
       run: |
         gh release create "$VERSION" release-artifacts/* --title "$VERSION" --generate-notes --latest=false
+        gh release edit "$VERSION" --latest=false
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - 'v*-godot3'
+  workflow_run:
+    workflows: ["CD - Build and Release"]
+    types:
+      - completed
+    branches:
+      - v1
 
 permissions:
   contents: write
@@ -10,6 +16,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Unsets the latest release badge by calling gh release edit right after gh release create, bypassing the gh CLI bug that ignores --latest=false when assets are uploaded.