### PR TITLE
ci: deploy docs on v1 branch push and v*-godot3 tags

### DIFF
--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -1,6 +1,8 @@
 name: "[CD] Deploy Documentation (v1)"
 on:
   push:
+    branches:
+      - v1
     tags:
       - 'v*-godot3'
 


### PR DESCRIPTION
Reverts documentation deployment triggers to run on both pushes to v1 branch and v*-godot3 tags.