### PR TITLE
fix: split mike delete commands and hide empty md-banner

### DIFF
--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -34,7 +34,8 @@ jobs:
           VERSION=$(echo "$CLEAN_VERSION" | cut -d. -f1,2)
           
           # Delete obsolete/incorrect versions from gh-pages if they exist
-          mike delete latest-godot3 1.3-godot3 --push || true
+          mike delete latest-godot3 --push || true
+          mike delete 1.3-godot3 --push || true
           
           # Deploy versioned folder (e.g. 1.3)
           mike deploy --push --update-aliases $VERSION

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,7 +5,10 @@
     <div class="announcement-wrapper">
       <script>
         if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1' && !window.location.pathname.includes('/latest/')) {
-          document.currentScript.parentElement.style.display = 'none';
+          var banner = document.currentScript.closest('[data-md-component="banner"]');
+          if (banner) {
+            banner.style.display = 'none';
+          }
         }
       </script>
       <div class="announcement-content">


### PR DESCRIPTION
Fixes the docs deployment by splitting mike delete commands, preventing failure if one version is missing. Also fixes the black empty banner line by hiding the grandparent md-banner element instead of just the inner wrapper.