### PR TITLE
ci: remove obsolete mike delete commands

### DIFF
--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -33,8 +33,6 @@ jobs:
           CLEAN_VERSION=$(echo "$BASE_VERSION" | sed 's/^v//')
           VERSION=$(echo "$CLEAN_VERSION" | cut -d. -f1,2)
           
-          # Delete obsolete/incorrect versions from gh-pages if they exist
-          mike delete latest-godot3 1.3-godot3 --push || true
-          
+
           # Deploy versioned folder (e.g. 1.3)
           mike deploy --push --update-aliases $VERSION

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,7 +5,7 @@
     <div class="announcement-wrapper">
       <script>
         if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1' && !window.location.pathname.includes('/latest/')) {
-          var banner = document.currentScript.closest('[data-md-component="banner"]');
+          var banner = document.currentScript.closest('.md-banner');
           if (banner) {
             banner.style.display = 'none';
           }
@@ -29,6 +29,13 @@
         </div>
       </div>
     </div>
+  {% else %}
+    <script>
+      var banner = document.currentScript.closest('.md-banner');
+      if (banner) {
+        banner.style.display = 'none';
+      }
+    </script>
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Removes the obsolete mike delete commands from the documentation deployment workflow since they have already been successfully deleted from the gh-pages branch.