### PR TITLE
fix: cron workflow should ignore Godot 3 (-godot3) tags

### DIFF
--- a/.github/workflows/cron-sync-godot-versions.yml
+++ b/.github/workflows/cron-sync-godot-versions.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         LATEST=$(gh api repos/godotengine/godot/releases --jq '[.[] | select(.tag_name | test("^4\\.[0-9]+(\\.[0-9]+)?-stable$")) | .tag_name][0]' | sed 's/-stable//')
         LATEST_PAD=$(echo "$LATEST" | awk -F. '{if(NF==2) print $0".0"; else print $0}')
-        TAG=$(gh api repos/${{ github.repository }}/releases --jq '[.[] | select(.prerelease == false and .draft == false) | .tag_name][0]')
+        TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name')
         RELEASE_EXISTS=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" > /dev/null 2>&1 && echo "true" || echo "false")
         
         if [ "$RELEASE_EXISTS" = "true" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ platforms/godot_editor/addons/admob/csharp/.gdignore
 # MkDocs local development version helper
 docs/versions.json
 
+android/

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ If you appreciate our work, don't forget to give us a star on GitHub! ⭐
 
 ![Star History Chart](https://api.star-history.com/svg?repos=poingstudios/godot-admob-plugin&type=Date)
 
-[VersionBadge]: https://badgen.net/github/release/poingstudios/godot-admob-plugin/stable?label=Version
+[VersionBadge]: https://img.shields.io/github/v/release/poingstudios/godot-admob-plugin
 [StarsBadge]: https://badgen.net/github/stars/poingstudios/godot-admob-plugin
 [DiscordBadge]: https://badgen.net/badge/_/Discord/7289DA?label=&icon=discord
 [LicenseBadge]: https://badgen.net/github/license/poingstudios/godot-admob-plugin?label=License


### PR DESCRIPTION
## Changes

- Use GitHub API `/releases/latest` endpoint instead of filtering all releases manually, so Godot 3 tags like `v1.3.6-godot3` are never picked up
- Added `android/` to `.gitignore`