### PR TITLE
fix: retain UMP ConsentForm instance to prevent GC of dismissed callback

### DIFF
--- a/platforms/godot_editor/addons/admob/csharp/src/Ump/Api/ConsentForm.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/Ump/Api/ConsentForm.cs
@@ -48,6 +48,7 @@ namespace PoingStudios.AdMob.Ump.Api
             if (_plugin == null) return;
 
             _onDismissedCallback = onConsentFormDismissed ?? ((_) => { });
+            UserMessagingPlatform.ActiveConsentForm = this;
             _plugin.Call("show", _uid);
             SafeConnect(_plugin, "on_consent_form_dismissed", _onDismissedCallable);
         }
@@ -56,6 +57,7 @@ namespace PoingStudios.AdMob.Ump.Api
         {
             if (uid != _uid) return;
 
+            UserMessagingPlatform.ActiveConsentForm = null;
             FormError formError = (errorDict != null && errorDict.Count > 0)
                 ? FormError.Create(errorDict)
                 : null;

--- a/platforms/godot_editor/addons/admob/csharp/src/Ump/Api/UserMessagingPlatform.cs
+++ b/platforms/godot_editor/addons/admob/csharp/src/Ump/Api/UserMessagingPlatform.cs
@@ -34,6 +34,8 @@ namespace PoingStudios.AdMob.Ump.Api
 
         public static ConsentInformation ConsentInformation { get; } = new ConsentInformation();
 
+        public static ConsentForm ActiveConsentForm { get; set; }
+
         private static Action<ConsentForm> _onLoadSuccessCallback;
         private static Action<FormError> _onLoadFailureCallback;
         private static Action<FormError> _onPrivacyOptionsFormDismissedCallback;

--- a/platforms/godot_editor/addons/admob/gdscript/src/ump/api/ConsentForm.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/src/ump/api/ConsentForm.gd
@@ -38,12 +38,14 @@ var _on_consent_form_dismissed_callback
 func show(on_consent_form_dismissed := func(form_error: FormError): pass) -> void:
 	if _plugin:
 		self._on_consent_form_dismissed_callback = on_consent_form_dismissed
+		UserMessagingPlatform.active_consent_form = self
 		_plugin.show(_uid)
 		safe_connect(_plugin, "on_consent_form_dismissed", _on_consent_form_dismissed)
 
 
 func _on_consent_form_dismissed(uid: int, form_error_dictionary: Dictionary) -> void:
 	if uid == _uid:
+		UserMessagingPlatform.active_consent_form = null
 		var formError: FormError = (
 			FormError.create(form_error_dictionary)
 			if not form_error_dictionary.is_empty()

--- a/platforms/godot_editor/addons/admob/gdscript/src/ump/api/UserMessagingPlatform.gd
+++ b/platforms/godot_editor/addons/admob/gdscript/src/ump/api/UserMessagingPlatform.gd
@@ -27,6 +27,8 @@ static var _plugin := _get_plugin("PoingGodotAdMobUserMessagingPlatform")
 
 static var consent_information := ConsentInformation.new()
 
+static var active_consent_form: ConsentForm
+
 static var _on_consent_form_load_success_listener_callback
 static var _on_consent_form_load_failure_listener_callback
 static var _on_privacy_options_form_dismissed_callback


### PR DESCRIPTION
## Summary

Fixes #423 — the UMP `ConsentForm` callback (`on_consent_form_dismissed`) was never invoked because `ConsentForm` is `RefCounted` and gets garbage-collected immediately after `load_consent_form` completes if the developer does not keep a strong reference to it.

We now retain a strong reference to the active `ConsentForm` instance internally in the UMP service, so it stays alive from `show()` until the native `on_consent_form_dismissed` signal fires.

## Changes

**GDScript**
- `UserMessagingPlatform.gd`: added `static var active_consent_form: ConsentForm`
- `ConsentForm.gd`: assign `self` to `UserMessagingPlatform.active_consent_form` in `show()`; set it back to `null` in `_on_consent_form_dismissed()` to release the reference and allow GC.

**C#** (1:1 parity with GDScript)
- `UserMessagingPlatform.cs`: added `public static ConsentForm ActiveConsentForm { get; set; }`
- `ConsentForm.cs`: assign `this` to `UserMessagingPlatform.ActiveConsentForm` in `Show()`; set it back to `null` in `OnConsentFormDismissed()`.

This is a Godot-side only fix (preventing GC of the `RefCounted` instance); no Android/iOS native bridge changes are required.

## Verification

- `gdlint platforms/godot_editor/addons/` — Success: no problems found
- GDScript/C# API parity maintained

## Related

Closes #423