### PR TITLE
chore: update sample to Godot 4.7.1

### DIFF
--- a/platforms/godot_editor/AdMobSample.csproj
+++ b/platforms/godot_editor/AdMobSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.7.0">
+<Project Sdk="Godot.NET.Sdk/4.7.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
Bumps `Godot.NET.Sdk` from 4.7.0 to 4.7.1 in `AdMobSample.csproj` to align the C# sample project with the plugin's current target Godot version (4.7.1).

Closes #437.