### PR TITLE
docs: translate v4-to-v5 legacy gdip deletion warning to pt-BR, es, zh, and ja

### DIFF
--- a/docs/migration.es.md
+++ b/docs/migration.es.md
@@ -253,6 +253,22 @@ En la versión 5.0.0, el plugin ha unificado todas las opciones de configuració
     
     En la versión 5, **el archivo `config.gd` ha sido completamente eliminado**. Debes transferir tus App IDs a la nueva ubicación en los Ajustes del Proyecto.
 
+!!! danger "Cambio Crítico en iOS: Elimine Archivos .gdip Heredados de v4 (Para Evitar Conflictos en Xcode)"
+    En la versión 4, los plugins de iOS se registraban mediante archivos de configuración `.gdip` ubicados en `res://ios/plugins/`.
+    En la versión 5, los frameworks y dependencias de iOS se agregan dinámicamente mediante el plugin del editor durante la exportación.
+    
+    **Debe eliminar todos los archivos heredados `poing-godot-admob*.gdip` y el directorio `res://ios/plugins/poing-godot-admob/`.** (No elimine el directorio `res://ios/plugins/` en sí si utiliza otros plugins de iOS que no sean de AdMob). No eliminar los archivos `.gdip` y binarios antiguos de AdMob provocará errores de símbolos y frameworks duplicados (`Multiple commands produce ...`) en Xcode.
+
+!!! danger "Cambio Crítico en iOS: Limpie las Opciones de Exportación Heredadas (Para Evitar Conflictos)"
+    En la versión 5, ya no necesita configurar manualmente el `Gad Application Identifier` ni marcar las opciones de plugins antiguos en las opciones del Preset de Exportación de iOS. El plugin lee automáticamente el App ID desde los **Ajustes del Proyecto** e inyecta los frameworks necesarios y el `GADApplicationIdentifier` en el `Info.plist` de su proyecto Xcode durante la exportación.
+    
+    **Es crítico que limpie estos campos antiguos y desmarque las opciones heredadas de AdMob en su Preset de Exportación de iOS.** De lo contrario, se producirán errores de símbolos duplicados y conflictos de plugins.
+
+!!! danger "Obligatorio: Actualizar Binarios Nativos de la Plataforma"
+    Después de actualizar los archivos del plugin del editor (GDScript/C#) en su proyecto, **debe** abrir el **AdMob Manager** en el Editor de Godot y hacer clic en **Download & Install** para ambas plataformas (Android e iOS) para descargar los binarios nativos v5.0.0 correspondientes.
+    
+    Si intenta exportar el proyecto con binarios nativos heredados (v4) o faltantes, el plugin de exportación bloqueará la exportación y mostrará un error para evitar cierres inesperados en tiempo de ejecución.
+
 Las opciones de configuración ahora se registran y configuran en **Ajustes del Proyecto > General**:
 
 * **Configuración de Android:** `admob/general/android/enabled`, `admob/general/android/app_id` y banderas de optimización.

--- a/docs/migration.ja.md
+++ b/docs/migration.ja.md
@@ -253,6 +253,12 @@ configurations.configureEach {
     
     バージョン 5 では、**`config.gd` は完全に削除されました**。既存の App ID を新しいプロジェクト設定の場所へ移行する必要があります。
 
+!!! danger "iOS の重要な変更点: レガシー v4 .gdip ファイルの削除（Xcode のビルド競合を回避）"
+    バージョン 4 では、iOS プラグインは `res://ios/plugins/` 内に配置された `.gdip` 設定ファイルを通じて登録されていました。
+    バージョン 5 では、iOS フレームワークと依存関係はエクスポート時にエディタープラグインによって動的に追加されます。
+    
+    **レガシーの `poing-godot-admob*.gdip` ファイルおよび `res://ios/plugins/poing-godot-admob/` ディレクトリをすべて削除する必要があります。**（他の非 AdMob iOS プラグインを使用している場合は、`res://ios/plugins/` ディレクトリ自体は削除しないでください）。古い AdMob `.gdip` ファイルやバイナリを削除しないと、Xcode でシンボルおよびフレームワークの重複エラー（`Multiple commands produce ...`）が発生します。
+
 設定オプションは、**プロジェクト設定 > 一般** から設定できるようになりました。
 
 * **Android 設定:** `admob/general/android/enabled`、`admob/general/android/app_id`、および最適化フラグ。

--- a/docs/migration.pt-BR.md
+++ b/docs/migration.pt-BR.md
@@ -263,6 +263,12 @@ Na versão 5.0.0, o plugin unificou todas as opções de configuração diretame
     Na versão 5, o **`config.gd` foi completamente removido**. Você deve transferir seus App IDs (tanto de Android quanto de iOS) para o novo local nas Project Settings.
     
 
+!!! danger "Alteração Crítica no iOS: Exclua Arquivos .gdip Legados da v4 (Para Evitar Conflitos no Xcode)"
+    Na versão 4, os plugins do iOS eram registrados via arquivos de configuração `.gdip` na pasta `res://ios/plugins/`.
+    Na versão 5, os frameworks e dependências do iOS são adicionados dinamicamente pelo plugin do editor durante o export.
+    
+    **Você deve excluir todos os arquivos legados `poing-godot-admob*.gdip` e o diretório `res://ios/plugins/poing-godot-admob/`.** (Não exclua o diretório `res://ios/plugins/` em si se você usar outros plugins de iOS que não sejam do AdMob). A não remoção dos arquivos `.gdip` e binários antigos do AdMob causará erros de símbolos e frameworks duplicados (`Multiple commands produce ...`) no Xcode.
+
 !!! danger "Alteração Crítica no iOS: Limpar Opções de Exportação Legadas (Para Evitar Conflitos)"
     Na versão 5, você não precisa mais definir manualmente o `Gad Application Identifier` ou marcar as opções de plugins antigos nas configurações de Exportação do iOS. O plugin lê automaticamente o App ID das **Project Settings** (Configurações do Projeto) e injeta os frameworks necessários e o `GADApplicationIdentifier` no arquivo `Info.plist` do seu projeto do Xcode durante a exportação.
     

--- a/docs/migration.zh.md
+++ b/docs/migration.zh.md
@@ -253,6 +253,12 @@ configurations.configureEach {
     
     在 v5 版本中，**`config.gd` 已经被彻底移除**。你必须将现有的 App ID 搬迁到项目设置中的新位置。
 
+!!! danger "iOS 关键变更：删除旧版 v4 .gdip 文件（避免 Xcode 冲突）"
+    在第 4 版中，iOS 插件是通过位于 `res://ios/plugins/` 的 `.gdip` 配置文件注册的。
+    在第 5 版中，iOS framework 和依赖项会在导出过程中由编辑器插件动态添加。
+    
+    **您必须删除所有旧版 `poing-godot-admob*.gdip` 文件以及 `res://ios/plugins/poing-godot-admob/` 目录。**（如果您使用了其他非 AdMob 的 iOS 插件，请勿删除 `res://ios/plugins/` 根目录本身）。如果不删除旧的 AdMob `.gdip` 文件和二进制文件，将导致 Xcode 中出现符号和 framework 重复错误（`Multiple commands produce ...`）。
+
 配置项现在已注册并可在 **Project Settings > General** 下进行配置：
 
 * **Android 设置:** `admob/general/android/enabled`、`admob/general/android/app_id` 以及各类初始化/加载优化标志。


### PR DESCRIPTION
## Summary
This Pull Request synchronizes the newly added iOS migration warning across all localized documentation files (`docs/migration.pt-BR.md`, `docs/migration.es.md`, `docs/migration.zh.md`, and `docs/migration.ja.md`) following the `doc-master` protocol.

The notice warns developers upgrading from v4 to v5 to delete legacy `poing-godot-admob*.gdip` files and the `res://ios/plugins/poing-godot-admob/` directory to prevent duplicate framework errors (`Multiple commands produce ...`) in Xcode.

## Locales Updated
- 🇧🇷 Brazilian Portuguese (`docs/migration.pt-BR.md`)
- 🇪🇸 Spanish (`docs/migration.es.md`)
- 🇨🇳 Simplified Chinese (`docs/migration.zh.md`)
- 🇯🇵 Japanese (`docs/migration.ja.md`)

## Verification
- Verified 1:1 structural parity with English `docs/migration.md`.
- Tested build using `mkdocs serve` (Clean build).