### PR TITLE
docs: fix Important Notes rendering on native video ads page

### DIFF
--- a/docs/ad_formats/native_video.es.md
+++ b/docs/ad_formats/native_video.es.md
@@ -80,17 +80,15 @@ Para manejar eventos de video específicos, cree un objeto `VideoLifecycleCallba
 
 ## Notas importantes
 
-> [!WARNING]
-> **Requisito de MediaView**
->
-> Si cargas un anuncio de video usando la plantilla `SMALL`, verás una advertencia de problema de implementación que indica:
-> `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`.
->
-> Esto sucede porque el SDK oficial de Google Mobile Ads requiere un `MediaView` visible para renderizar el video, pero el diseño compacto de la plantilla `SMALL` no lo admite o incluye de forma predeterminada. Si tu bloque de anuncios publica anuncios de video, **debes usar la plantilla `MEDIUM`** que incluye un `MediaView` integrado.
+!!! warning "Requisito de MediaView"
 
-> [!NOTE]
-> **Valores de MediaContent (Duración y Relación de Aspecto)**
->
-> Los valores como la duración del video y la relación de aspecto del objeto `MediaContent` devolverán `0.0` si se consultan inmediatamente dentro de la función de callback `on_ad_loaded`. Debes consultarlos **después** de llamar a `render_template()`, una vez que la vista del anuncio se haya inflado y diseñado en pantalla.
+    Si cargas un anuncio de video usando la plantilla `SMALL`, verás una advertencia de problema de implementación que indica:
+    `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`.
+
+    Esto sucede porque el SDK oficial de Google Mobile Ads requiere un `MediaView` visible para renderizar el video, pero el diseño compacto de la plantilla `SMALL` no lo admite o incluye de forma predeterminada. Si tu bloque de anuncios publica anuncios de video, **debes usar la plantilla `MEDIUM`** que incluye un `MediaView` integrado.
+
+!!! note "Valores de MediaContent (Duración y Relación de Aspecto)"
+
+    Los valores como la duración del video y la relación de aspecto del objeto `MediaContent` devolverán `0.0` si se consultan inmediatamente dentro de la función de callback `on_ad_loaded`. Debes consultarlos **después** de llamar a `render_template()`, una vez que la vista del anuncio se haya inflado y diseñado en pantalla.
 
 

--- a/docs/ad_formats/native_video.ja.md
+++ b/docs/ad_formats/native_video.ja.md
@@ -80,15 +80,13 @@ hide:
 
 ## 重要な注意点
 
-> [!WARNING]
-> **MediaViewの要件**
->
-> `SMALL` テンプレートを使用して動画広告をロードすると、実装の問題に関する次のような警告が表示されます：
-> `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset` (メインの画像または動画アセットにMediaViewが使用されていません。メインの画像または動画アセットを表示するには、ImageViewの代わりにMediaViewを使用してください)。
->
-> これは、公式のGoogle Mobile Ads SDKが動画をレンダリングするために表示可能な `MediaView` を必要とするのに対し、コンパクトな `SMALL` テンプレートレイアウトにはデフォルトで機能するものが含まれていないためです。動画広告を配信する広告ユニットを使用する場合は、ビルトインの `MediaView` が含まれている **`MEDIUM` テンプレートを使用する必要があります**。
+!!! warning "MediaViewの要件"
 
-> [!NOTE]
-> **MediaContent の値 (再生時間とアスペクト比)**
->
-> `on_ad_loaded` コールバック内で `MediaContent` オブジェクトから動画の再生時間やアスペクト比をすぐに照会すると、`0.0` が返されます。これらの値は、広告ビューがインフレートされてレイアウトされた後、つまり `render_template()` を呼び出した**後**に照会する必要があります。
+    `SMALL` テンプレートを使用して動画広告をロードすると、実装の問題に関する次のような警告が表示されます：
+    `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset` (メインの画像または動画アセットにMediaViewが使用されていません。メインの画像または動画アセットを表示するには、ImageViewの代わりにMediaViewを使用してください)。
+
+    これは、公式のGoogle Mobile Ads SDKが動画をレンダリングするために表示可能な `MediaView` を必要とするのに対し、コンパクトな `SMALL` テンプレートレイアウトにはデフォルトで機能するものが含まれていないためです。動画広告を配信する広告ユニットを使用する場合は、ビルトインの `MediaView` が含まれている **`MEDIUM` テンプレートを使用する必要があります**。
+
+!!! note "MediaContent の値 (再生時間とアスペクト比)"
+
+    `on_ad_loaded` コールバック内で `MediaContent` オブジェクトから動画の再生時間やアスペクト比をすぐに照会すると、`0.0` が返されます。これらの値は、広告ビューがインフレートされてレイアウトされた後、つまり `render_template()` を呼び出した**後**に照会する必要があります。

--- a/docs/ad_formats/native_video.md
+++ b/docs/ad_formats/native_video.md
@@ -80,17 +80,15 @@ To handle specific video events, create a `VideoLifecycleCallbacks` object and a
 
 ## Important Notes
 
-> [!WARNING]
-> **MediaView Requirement**
->
-> If you load a video ad using the `SMALL` template, you will see an implementation issue/warning stating:
-> `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`.
->
-> This happens because the official Google Mobile Ads SDK requires a visible `MediaView` to render the video, but the compact `SMALL` template layout does not support or include a functional one by default. If your ad unit serves video ads, you **must use the `MEDIUM` template** which includes a built-in `MediaView`.
+!!! warning "MediaView Requirement"
 
-> [!NOTE]
-> **MediaContent Values (Duration & Aspect Ratio)**
->
-> Values like video duration and aspect ratio from the `MediaContent` object will return `0.0` if queried immediately inside the `on_ad_loaded` callback. You must query them **after** calling `render_template()`, once the ad view has been inflated and laid out.
+    If you load a video ad using the `SMALL` template, you will see an implementation issue/warning stating:
+    `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`.
+
+    This happens because the official Google Mobile Ads SDK requires a visible `MediaView` to render the video, but the compact `SMALL` template layout does not support or include a functional one by default. If your ad unit serves video ads, you **must use the `MEDIUM` template** which includes a built-in `MediaView`.
+
+!!! note "MediaContent Values (Duration & Aspect Ratio)"
+
+    Values like video duration and aspect ratio from the `MediaContent` object will return `0.0` if queried immediately inside the `on_ad_loaded` callback. You must query them **after** calling `render_template()`, once the ad view has been inflated and laid out.
 
 

--- a/docs/ad_formats/native_video.pt-BR.md
+++ b/docs/ad_formats/native_video.pt-BR.md
@@ -80,17 +80,15 @@ Para lidar com eventos específicos de vídeo, crie um objeto `VideoLifecycleCal
 
 ## Notas Importantes
 
-> [!WARNING]
-> **Requisito do MediaView**
->
-> Se você carregar um anúncio em vídeo usando o modelo `SMALL`, verá um aviso de problema de implementação indicando:
-> `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`.
->
-> Isso ocorre porque o SDK oficial do Google Mobile Ads exige um `MediaView` visível para renderizar o vídeo, mas o layout compacto do modelo `SMALL` não suporta ou inclui um funcional por padrão. Se o seu bloco de anúncios veicula anúncios em vídeo, você **deve usar o modelo `MEDIUM`**, que inclui um `MediaView` integrado.
+!!! warning "Requisito do MediaView"
 
-> [!NOTE]
-> **Valores do MediaContent (Duração e Proporção)**
->
-> Valores como duração do vídeo e proporção de tela (aspect ratio) do objeto `MediaContent` retornarão `0.0` se forem consultados imediatamente no callback `on_ad_loaded`. Você deve consultá-los **após** chamar `render_template()`, uma vez que a exibição do anúncio tenha sido inflada e configurada na tela.
+    Se você carregar um anúncio em vídeo usando o modelo `SMALL`, verá um aviso de problema de implementação indicando:
+    `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`.
+
+    Isso ocorre porque o SDK oficial do Google Mobile Ads exige um `MediaView` visível para renderizar o vídeo, mas o layout compacto do modelo `SMALL` não suporta ou inclui um funcional por padrão. Se o seu bloco de anúncios veicula anúncios em vídeo, você **deve usar o modelo `MEDIUM`**, que inclui um `MediaView` integrado.
+
+!!! note "Valores do MediaContent (Duração e Proporção)"
+
+    Valores como duração do vídeo e proporção de tela (aspect ratio) do objeto `MediaContent` retornarão `0.0` se forem consultados imediatamente no callback `on_ad_loaded`. Você deve consultá-los **após** chamar `render_template()`, uma vez que a exibição do anúncio tenha sido inflada e configurada na tela.
 
 

--- a/docs/ad_formats/native_video.zh.md
+++ b/docs/ad_formats/native_video.zh.md
@@ -80,16 +80,14 @@ hide:
 
 ## 重要提示
 
-> [!WARNING]
-> **MediaView 要求**
->
-> 如果您使用 `SMALL` 模板加载视频广告，您会看到一条实现问题/警告，指出：
-> `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`。
->
-> 这是因为官方 Google Mobile Ads SDK 需要可见的 `MediaView` 来渲染视频，但紧凑的 `SMALL` 模板布局默认不支持或包含一个功能性的视图。如果您的广告单元提供视频广告，您**必须使用包含内置 `MediaView` 的 `MEDIUM` 模板**。
+!!! warning "MediaView 要求"
 
-> [!NOTE]
-> **MediaContent 数值（时长与宽高比）**
->
-> 如果在 `on_ad_loaded` 回调中立即查询，`MediaContent` 对象中的视频时长和宽高比等数值将返回 `0.0`。您必须在调用 `render_template()` **之后**进行查询，此时广告视图已被实例化并完成布局。
+    如果您使用 `SMALL` 模板加载视频广告，您会看到一条实现问题/警告，指出：
+    `MediaView not used for main image or video asset. Use MediaView instead of ImageView to show the main image or video asset`。
+
+    这是因为官方 Google Mobile Ads SDK 需要可见的 `MediaView` 来渲染视频，但紧凑的 `SMALL` 模板布局默认不支持或包含一个功能性的视图。如果您的广告单元提供视频广告，您**必须使用包含内置 `MediaView` 的 `MEDIUM` 模板**。
+
+!!! note "MediaContent 数值（时长与宽高比）"
+
+    如果在 `on_ad_loaded` 回调中立即查询，`MediaContent` 对象中的视频时长和宽高比等数值将返回 `0.0`。您必须在调用 `render_template()` **之后**进行查询，此时广告视图已被实例化并完成布局。
 


### PR DESCRIPTION
Resolves #470 

The "Native ad videos" page was using GitHub-style alerts rather than the MkDocs admonitions

## What's changed

- Converted to `!!! warning` and `!!! note` syntax
- Locales: en, pt-BR, es, zh, ja
- Text moved but not changed

## Screenshot

<img width="923" height="347" alt="image" src="https://github.com/user-attachments/assets/d79df3c4-0ac7-4cd6-845f-68c25952e4b4" />



