### PR TITLE
feat(v1): add Godot 3.6.3 support and manual template build workflows

### DIFF
--- a/.github/workflows/cd-build-and-release.yml
+++ b/.github/workflows/cd-build-and-release.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        GODOT_VERSIONS: ["3.5", "3.5.1", "3.5.2", "3.5.3", "3.6", "3.6.1", "3.6.2"]
+        GODOT_VERSIONS: ["3.5", "3.5.1", "3.5.2", "3.5.3", "3.6", "3.6.1", "3.6.2", "3.6.3"]
     steps:
     - uses: actions/checkout@v3
 
@@ -135,7 +135,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        GODOT_VERSIONS: ["3.5", "3.5.1", "3.5.2", "3.5.3", "3.6", "3.6.1", "3.6.2"]
+        GODOT_VERSIONS: ["3.5", "3.5.1", "3.5.2", "3.5.3", "3.6", "3.6.1", "3.6.2", "3.6.3"]
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/cd-manual-build-android.yml
+++ b/.github/workflows/cd-manual-build-android.yml
@@ -1,0 +1,104 @@
+name: "[Manual] Build Android Template for Single Godot Version"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of the existing release (e.g., v1.3.6-godot3). Required if uploading to release.'
+        required: false
+      godot_version:
+        description: 'Godot version to build for (e.g., 3.6.3 or 3.6-beta1)'
+        required: true
+      upload_to_release:
+        description: 'Upload to GitHub Release? (If false, saves as workflow artifact only)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  setup:
+    name: Parse version and validate
+    runs-on: ubuntu-latest
+    outputs:
+      godot_version: ${{ steps.version.outputs.version }}
+    steps:
+    - name: Parse and validate version
+      id: version
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.inputs.tag }}
+        UPLOAD: ${{ github.event.inputs.upload_to_release }}
+      run: |
+        CV="${{ github.event.inputs.godot_version }}"
+        if [[ ! "$CV" =~ \. ]]; then CV="${CV}.0"; fi
+        echo "version=${CV}" >> $GITHUB_OUTPUT
+
+        if [ "$UPLOAD" = "true" ]; then
+          if [ -z "$TAG" ]; then
+            echo "::error::Tag is required when uploading to a release."
+            exit 1
+          fi
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release $TAG does not exist. This workflow only adds files to existing releases."
+            exit 1
+          fi
+          echo "Release $TAG found. Will upload to release."
+        else
+          echo "Upload to release is disabled. Artifact will be saved to workflow only."
+        fi
+
+  android-template:
+    needs: setup
+    name: Compiling Android (Godot ${{ needs.setup.outputs.godot_version }})
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Cache Gradle
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: android-gradle-${{ needs.setup.outputs.godot_version }}-${{ hashFiles('platforms/android/**/*.gradle*', 'platforms/android/gradle.properties') }}
+        restore-keys: |
+          android-gradle-${{ needs.setup.outputs.godot_version }}-
+          android-gradle-
+
+    - name: Build Plugins
+      working-directory: platforms/android
+      run: |
+        chmod +x ./scripts/unix/download_godot.sh
+        ./scripts/unix/download_godot.sh ${{ needs.setup.outputs.godot_version }}
+        chmod +x ./gradlew
+        ./gradlew build -PgodotVersion=${{ needs.setup.outputs.godot_version }}
+
+    - name: Compress the artifact output
+      working-directory: platforms/android
+      run: |
+        mkdir -p .output
+        cd admob
+        zip -r ../.output/android-template-v${{ needs.setup.outputs.godot_version }}.zip AdMob.gdap build/outputs/aar/admob-release.aar build/outputs/aar/admob-debug.aar
+
+    - name: Upload to GitHub Release
+      if: github.event.inputs.upload_to_release == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.inputs.tag }}
+      run: |
+        gh release upload "$TAG" platforms/android/.output/android-template-v${{ needs.setup.outputs.godot_version }}.zip --clobber --repo "${{ github.repository }}"
+
+    - name: Upload as workflow artifact
+      if: github.event.inputs.upload_to_release == 'false'
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-${{ needs.setup.outputs.godot_version }}
+        path: platforms/android/.output/android-template-v${{ needs.setup.outputs.godot_version }}.zip

--- a/.github/workflows/cd-manual-build-ios.yml
+++ b/.github/workflows/cd-manual-build-ios.yml
@@ -1,0 +1,118 @@
+name: "[Manual] Build iOS Template for Single Godot Version"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of the existing release (e.g., v1.3.6-godot3). Required if uploading to release.'
+        required: false
+      godot_version:
+        description: 'Godot version to build for (e.g., 3.6.3 or 3.6-beta1)'
+        required: true
+      upload_to_release:
+        description: 'Upload to GitHub Release? (If false, saves as workflow artifact only)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  setup:
+    name: Parse version and validate
+    runs-on: ubuntu-latest
+    outputs:
+      godot_version: ${{ steps.version.outputs.version }}
+    steps:
+    - name: Parse and validate version
+      id: version
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.inputs.tag }}
+        UPLOAD: ${{ github.event.inputs.upload_to_release }}
+      run: |
+        CV="${{ github.event.inputs.godot_version }}"
+        if [[ ! "$CV" =~ \. ]]; then CV="${CV}.0"; fi
+        echo "version=${CV}" >> $GITHUB_OUTPUT
+
+        if [ "$UPLOAD" = "true" ]; then
+          if [ -z "$TAG" ]; then
+            echo "::error::Tag is required when uploading to a release."
+            exit 1
+          fi
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release $TAG does not exist. This workflow only adds files to existing releases."
+            exit 1
+          fi
+          echo "Release $TAG found. Will upload to release."
+        else
+          echo "Upload to release is disabled. Artifact will be saved to workflow only."
+        fi
+
+  ios-template:
+    needs: setup
+    name: Compiling iOS (Godot ${{ needs.setup.outputs.godot_version }})
+    runs-on: "macos-latest"
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache & Load Python/SPM
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install scons
+      run: python -m pip install scons
+
+    - name: Load .scons_cache directory
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.workspace }}/platforms/ios/godot/.scons_cache/
+        key: scons-ios-${{ needs.setup.outputs.godot_version }}-${{ hashFiles('platforms/ios/SConstruct', 'platforms/ios/scripts/**') }}
+        restore-keys: |
+          scons-ios-${{ needs.setup.outputs.godot_version }}-
+          scons-ios-
+
+    - name: Cache SPM dependencies
+      uses: actions/cache@v3
+      with:
+        path: platforms/ios/.build
+        key: spm-${{ hashFiles('platforms/ios/Package.swift', 'platforms/ios/Package.resolved') }}
+        restore-keys: |
+          spm-
+
+    - name: Compiles the Source Code
+      working-directory: platforms/ios
+      env:
+        SCONS_CACHE: ${{ github.workspace }}/platforms/ios/godot/.scons_cache/
+      run: |
+        chmod +x ./scripts/lib/download_godot.sh
+        ./scripts/lib/download_godot.sh ${{ needs.setup.outputs.godot_version }}
+        chmod +x ./scripts/resolve_spm_deps.sh
+        ./scripts/resolve_spm_deps.sh
+        chmod +x ./scripts/generate_headers.sh
+        ./scripts/generate_headers.sh 3.x
+        chmod +x ./scripts/release_static_library.sh
+        chmod +x ./scripts/generate_static_library.sh
+        ./scripts/release_static_library.sh 3.x
+
+    - name: Compress the artifact output
+      working-directory: platforms/ios/bin/release/admob
+      run: |
+        mkdir -p ../.output
+        zip -r ../.output/ios-template-v${{ needs.setup.outputs.godot_version }}.zip admob.gdip admob
+
+    - name: Upload to GitHub Release
+      if: github.event.inputs.upload_to_release == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.inputs.tag }}
+      run: |
+        gh release upload "$TAG" platforms/ios/bin/release/.output/ios-template-v${{ needs.setup.outputs.godot_version }}.zip --clobber --repo "${{ github.repository }}"
+
+    - name: Upload as workflow artifact
+      if: github.event.inputs.upload_to_release == 'false'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ios-${{ needs.setup.outputs.godot_version }}
+        path: platforms/ios/bin/release/.output/ios-template-v${{ needs.setup.outputs.godot_version }}.zip

--- a/scripts/build_local.sh
+++ b/scripts/build_local.sh
@@ -8,12 +8,12 @@ show_help() {
     echo ""
     echo "Arguments:"
     echo "  [platform]       android, ios, or all (default: all)"
-    echo "  <godot_version>  The target Godot version (e.g. 3.6.2)"
+    echo "  <godot_version>  The target Godot version (e.g. 3.6.3)"
     echo ""
     echo "Examples:"
-    echo "  ./scripts/build_local.sh all 3.6.2"
-    echo "  ./scripts/build_local.sh ios 3.6.2"
-    echo "  ./scripts/build_local.sh android 3.6.2"
+    echo "  ./scripts/build_local.sh all 3.6.3"
+    echo "  ./scripts/build_local.sh ios 3.6.3"
+    echo "  ./scripts/build_local.sh android 3.6.3"
 }
 
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then
@@ -25,7 +25,7 @@ PLATFORM=${1:-all}
 GODOT_VERSION=$2
 
 if [ -z "$GODOT_VERSION" ]; then
-    echo "[ERROR] Please specify target Godot version (e.g., 3.6.2)."
+    echo "[ERROR] Please specify target Godot version (e.g., 3.6.3)."
     show_help
     exit 1
 fi


### PR DESCRIPTION
## Description
This PR adds support for the newly released Godot 3.6.3 and introduces manual template build workflows for Godot 3.

### Changes
- **CI / Build Matrix**: Added `3.6.3` to both `android-template` and `ios-template` build matrices in `cd-build-and-release.yml`.
- **Manual Workflows**:
  - Added `.github/workflows/cd-manual-build-android.yml` to build single Android templates and upload them to existing releases via `workflow_dispatch`.
  - Added `.github/workflows/cd-manual-build-ios.yml` to build single iOS static library templates and upload them to existing releases via `workflow_dispatch`.
- **Local Scripts**: Updated version example references in `scripts/build_local.sh` to `3.6.3`.