### PR TITLE
ci(v1): upgrade actions/cache to v6 and enable SCons CacheDir for iOS

### DIFF
--- a/.github/workflows/cd-build-and-release.yml
+++ b/.github/workflows/cd-build-and-release.yml
@@ -95,7 +95,7 @@ jobs:
         java-version: '17'
 
     - name: Cache Gradle
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: |
           ~/.gradle/caches
@@ -154,7 +154,7 @@ jobs:
       run: python -m pip install scons
 
     - name: Load .scons_cache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/platforms/ios/godot/.scons_cache/
         key: scons-ios-${{ env.CURRENT_GODOT_VERSION }}-${{ hashFiles('platforms/ios/SConstruct', 'platforms/ios/scripts/**') }}
@@ -163,7 +163,7 @@ jobs:
           scons-ios-
 
     - name: Cache SPM dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: platforms/ios/.build
         key: spm-${{ hashFiles('platforms/ios/Package.swift', 'platforms/ios/Package.resolved') }}

--- a/.github/workflows/cd-deploy-docs.yml
+++ b/.github/workflows/cd-deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@v6
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/cd-manual-build-android.yml
+++ b/.github/workflows/cd-manual-build-android.yml
@@ -63,7 +63,7 @@ jobs:
         java-version: '17'
 
     - name: Cache Gradle
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/cd-manual-build-ios.yml
+++ b/.github/workflows/cd-manual-build-ios.yml
@@ -65,7 +65,7 @@ jobs:
       run: python -m pip install scons
 
     - name: Load .scons_cache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/platforms/ios/godot/.scons_cache/
         key: scons-ios-${{ needs.setup.outputs.godot_version }}-${{ hashFiles('platforms/ios/SConstruct', 'platforms/ios/scripts/**') }}
@@ -74,7 +74,7 @@ jobs:
           scons-ios-
 
     - name: Cache SPM dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: platforms/ios/.build
         key: spm-${{ hashFiles('platforms/ios/Package.swift', 'platforms/ios/Package.resolved') }}

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -18,6 +18,11 @@ opts = Variables([], ARGUMENTS)
 # Gets the standard flags CC, CCX, etc.
 env = DefaultEnvironment()
 
+scons_cache_path = os.environ.get("SCONS_CACHE")
+if scons_cache_path:
+    CacheDir(scons_cache_path)
+    Decider("MD5")
+
 # Define our options
 opts.Add(EnumVariable('target', "Compilation target", 'debug', ['debug', 'release', "release_debug"]))
 opts.Add(EnumVariable('arch', "Compilation Architecture", '', ['', 'arm64', 'armv7', 'x86_64']))


### PR DESCRIPTION
## Description
This PR upgrades GitHub Actions caching across all `v1` workflows and enables native SCons caching on iOS.

### Changes
- **Cache Upgrade**: Bumped all `actions/cache` references from `v3` to `v6` in `cd-build-and-release.yml`, `cd-deploy-docs.yml`, `cd-manual-build-android.yml`, and `cd-manual-build-ios.yml`.
- **iOS SCons Cache**: Added `CacheDir(scons_cache_path)` and `Decider("MD5")` to `platforms/ios/SConstruct` so SCons actively reads and writes compiled artifacts to `.scons_cache/`.