### PR TITLE
ci: enable SCons CacheDir for iOS and add caching to manual build workflows

### DIFF
--- a/.github/workflows/cd-manual-build-android.yml
+++ b/.github/workflows/cd-manual-build-android.yml
@@ -54,6 +54,23 @@ jobs:
       with:
         ref: ${{ github.event.inputs.tag || github.ref }}
 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Cache Gradle
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: android-gradle-${{ needs.setup.outputs.godot_version }}-${{ hashFiles('platforms/android/**/*.gradle*', 'platforms/android/gradle.properties') }}
+        restore-keys: |
+          android-gradle-${{ needs.setup.outputs.godot_version }}-
+          android-gradle-
+
     - name: Build Plugins
       working-directory: platforms/android
       run: |

--- a/.github/workflows/cd-manual-build-ios.yml
+++ b/.github/workflows/cd-manual-build-ios.yml
@@ -59,8 +59,27 @@ jobs:
       with: { python-version: '3.x' }
     - run: python -m pip install scons
 
+    - name: Load .scons_cache directory
+      uses: actions/cache@v6
+      with:
+        path: ${{ github.workspace }}/platforms/ios/godot/.scons_cache/
+        key: scons-ios-${{ needs.setup.outputs.godot_version }}-${{ hashFiles('platforms/ios/SConstruct', 'platforms/ios/scripts/**') }}
+        restore-keys: |
+          scons-ios-${{ needs.setup.outputs.godot_version }}-
+          scons-ios-
+
+    - name: Cache SPM dependencies
+      uses: actions/cache@v6
+      with:
+        path: platforms/ios/.build
+        key: spm-${{ hashFiles('platforms/ios/Package.swift', 'platforms/ios/Package.resolved') }}
+        restore-keys: |
+          spm-
+
     - name: Build Source
       working-directory: platforms/ios
+      env:
+        SCONS_CACHE: ${{ github.workspace }}/platforms/ios/godot/.scons_cache/
       run: ./scripts/build.sh ${{ needs.setup.outputs.godot_version }}
 
     - name: Upload to GitHub Release

--- a/platforms/ios/SConstruct
+++ b/platforms/ios/SConstruct
@@ -20,6 +20,11 @@ opts = Variables([], ARGUMENTS)
 # Gets the standard flags CC, CCX, etc.
 env = DefaultEnvironment()
 
+scons_cache_path = os.environ.get("SCONS_CACHE")
+if scons_cache_path:
+    CacheDir(scons_cache_path)
+    Decider("MD5")
+
 # Define our options
 opts.Add(EnumVariable('target', "Compilation target", 'debug', ['debug', 'release', "release_debug"]))
 opts.Add(EnumVariable('arch', "Compilation Architecture", '', ['', 'arm64', 'armv7', 'x86_64']))


### PR DESCRIPTION
## Description
This PR enables native SCons compilation caching for iOS builds and adds Gradle/SCons/SPM caching to the manual single-version build workflows.

### Changes
- **iOS SCons Cache**: Added `CacheDir(scons_cache_path)` and `Decider("MD5")` to `platforms/ios/SConstruct` so SCons actively reads and writes compiled objects into `.scons_cache/`.
- **Manual Android Builds**: Added `Set up JDK 17` and `Cache Gradle` steps to `cd-manual-build-android.yml`.
- **Manual iOS Builds**: Added `Load .scons_cache directory`, `Cache SPM dependencies`, and `SCONS_CACHE` environment variable to `cd-manual-build-ios.yml`.