### PR TITLE
fix(ci): anchor root build ignores in .gitignore and use git add -u in cron sync

### DIFF
--- a/.github/workflows/cron-sync-admob-dependencies.yml
+++ b/.github/workflows/cron-sync-admob-dependencies.yml
@@ -73,7 +73,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           git checkout -B "$BRANCH_NAME"
-          git add platforms/android/src/ platforms/ios/src/
+          git add -u platforms/android/src/ platforms/ios/src/
           git commit -m "chore(deps): update AdMob and mediation SDKs across Android and iOS"
           git push -f origin "$BRANCH_NAME"
           

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ __pycache__/
 /site/
 /platforms/godot_editor/android/
 /platforms/godot_editor/ios/
+/android/
+/ios/
 
 # Exceptions
 !platforms/godot_editor/addons/admob/icon.png
@@ -51,5 +53,3 @@ platforms/godot_editor/addons/admob/csharp/.gdignore
 
 # MkDocs local development version helper
 docs/versions.json
-
-android/


### PR DESCRIPTION
## 🐛 Bug Explanation & Solution

### 1. Root Cause of Failure in [Run 32657574830](https://github.com/poingstudios/godot-admob-plugin/actions/runs/32657574830/job/97238649768)
In `.gitignore`, the ignore pattern `android/` was unanchored (missing the leading slash `/`). In Git syntax, this caused Git to treat **any** folder named `android` at any depth (including `platforms/android/`) as ignored.

When the workflow ran `git add platforms/android/src/ platforms/ios/src/`, Git aborted with:
```text
The following paths are ignored by one of your .gitignore files:
platforms/android
##[error]Process completed with exit code 1.
```

### 2. Solution Implemented

1. **Anchored Root Build Ignores in `.gitignore`:**
   - Changed to `/android/` and `/ios/` (with leading slash `/`), strictly ignoring root `./android/` build folders while leaving `platforms/android/` completely untouched (matching the standard from `v1`).

2. **Switched to `git add -u` in `.github/workflows/cron-sync-admob-dependencies.yml`:**
   - Using `git add -u platforms/android/src/ platforms/ios/src/` ensures that only existing tracked `.gd` files modified by the sync script are staged, avoiding any untracked/ignored file conflicts.