### PR TITLE
fix(reviewer): correct GraphQL schema for reviewThreads comment review IDs

### DIFF
--- a/.github/scripts/poing_reviewer/github_api.py
+++ b/.github/scripts/poing_reviewer/github_api.py
@@ -107,12 +107,12 @@ def fetch_review_threads(owner, repo_name, pr_number, token):
               isResolved
               path
               line
-              pullRequestReview { databaseId }
               comments(first: 50) {
                 nodes {
                   author { login }
                   body
                   databaseId
+                  pullRequestReview { databaseId }
                   reactions(first: 10) {
                     nodes { content }
                   }

--- a/.github/scripts/poing_reviewer/reviewer.py
+++ b/.github/scripts/poing_reviewer/reviewer.py
@@ -309,7 +309,9 @@ The repository has an AGENTS.md file with project-specific rules. Follow these g
             for t in threads:
                 if not t or t.get("isResolved", False):
                     continue
-                review_node = t.get("pullRequestReview") or {}
+                comments = (t.get("comments") or {}).get("nodes") or []
+                first_comment = comments[0] if comments else {}
+                review_node = first_comment.get("pullRequestReview") or {}
                 thread_review_id = review_node.get("databaseId")
                 if thread_review_id and thread_review_id in stale_review_ids:
                     try:


### PR DESCRIPTION
## 🐛 Bug Explanation & Solution

### 1. Root Cause
In GitHub's GraphQL API schema, `PullRequestReviewThread` does not contain a `pullRequestReview` field. Instead, `pullRequestReview` belongs to `PullRequestReviewComment` (under `comments.nodes`).

Because `fetch_review_threads()` in `github_api.py` requested `pullRequestReview { databaseId }` directly on `PullRequestReviewThread`, GitHub rejected the query with:
```text
GraphQL errors (fetch_review_threads): [{"path": ["query", "repository", "pullRequest", "reviewThreads", "nodes", "pullRequestReview"], "extensions": {"code": "undefinedField", "typeName": "PullRequestReviewThread", "fieldName": "pullRequestReview"}, "message": "Field 'pullRequestReview' doesn't exist on type 'PullRequestReviewThread'"}]
```
This caused `fetch_review_threads()` to fail and return an empty list `[]` on every reviewer run.

### 2. Solution Implemented
1. **Moved `pullRequestReview` inside `comments.nodes` in `github_api.py`:** Matches the official GitHub GraphQL schema.
2. **Updated `reviewer.py`:** Extracts `thread_review_id` from the thread's first comment node (`comments.nodes[0].pullRequestReview.databaseId`).
3. **Verified Locally:** Tested GraphQL query against live PR #490 with `gh auth token` — successfully returned all 12 review threads with 0 errors.