### PR TITLE
fix(ios): link JavaScriptCore framework for SPM dependencies and iOS export

### DIFF
--- a/platforms/godot_editor/addons/admob/internal/exporters/ios/export_plugin.gd
+++ b/platforms/godot_editor/addons/admob/internal/exporters/ios/export_plugin.gd
@@ -294,7 +294,10 @@ let package = Package(
             name: "PoingGodotAdMobDeps",
             dependencies: [
 %s            ],
-            path: "PoingGodotAdMobDeps"
+            path: "PoingGodotAdMobDeps",
+            linkerSettings: [
+                .linkedFramework("JavaScriptCore")
+            ]
         )
     ]
 )

--- a/platforms/ios/Package.swift
+++ b/platforms/ios/Package.swift
@@ -147,6 +147,9 @@ let package = Package(
                 "../../godot",
                 "../../bin",
                 "../../.build"
+            ],
+            linkerSettings: [
+                .linkedFramework("JavaScriptCore")
             ]
         )
     ]

--- a/platforms/ios/src/ads/config/poing_godot_admob_ads.gd
+++ b/platforms/ios/src/ads/config/poing_godot_admob_ads.gd
@@ -40,7 +40,10 @@ func get_deinitialization_method() -> String:
 
 
 func get_system_dependencies() -> PackedStringArray:
-	return PackedStringArray(["AppTrackingTransparency.framework"])
+	return PackedStringArray([
+		"AppTrackingTransparency.framework",
+		"JavaScriptCore.framework"
+	])
 
 
 func get_files_to_copy() -> PackedStringArray:
@@ -51,7 +54,11 @@ func get_files_to_copy() -> PackedStringArray:
 
 
 func get_linker_flags() -> PackedStringArray:
-	return PackedStringArray(["-ObjC"])
+	return PackedStringArray([
+		"-ObjC",
+		"-framework",
+		"JavaScriptCore"
+	])
 
 
 func get_plist_content() -> String:


### PR DESCRIPTION
## Description

Resolves undefined symbol linker error during iOS Xcode Archive build:
```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_JSContext", referenced from:
      objc-class-ref in GADOMIDLightJSExecutor.o
ld: symbol(s) not found for architecture arm64
```

The Google Mobile Ads SDK (v12+) requires Apple's `JavaScriptCore.framework` for Open Measurement ad viewability tracking. Because Google's SPM package lacks the linker setting, this PR ensures `JavaScriptCore` is linked across all build and export pipelines.

## Changes

- **`platforms/godot_editor/addons/admob/internal/exporters/ios/export_plugin.gd`**: Added `linkerSettings: [.linkedFramework("JavaScriptCore")]` to generated `Package.swift` (Godot 4.3 - 4.7).
- **`platforms/ios/Package.swift`**: Added `linkerSettings: [.linkedFramework("JavaScriptCore")]` to `PoingGodotAdMobDeps` (Local builds & CI).
- **`platforms/ios/src/ads/config/poing_godot_admob_ads.gd`**: Added `"JavaScriptCore.framework"` to `get_system_dependencies()` and `"-framework", "JavaScriptCore"` to `get_linker_flags()` (Godot 4.8+ native export).

Closes #480