### PR TITLE
docs: update license copyright year to 2020-present

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -19,6 +19,9 @@ jobs:
         filters: |
           code:
             - 'platforms/**'
+            - '!platforms/**/LICENSE*'
+            - '!platforms/**/*.md'
+            - '!platforms/**/*.txt'
             - 'scripts/**'
             - '.github/workflows/**'
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-present Poing Studios
+Copyright (c) 2020-present Poing Studios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/poingstudios
 copyright: |
-  &copy; 2023-{current_year} <a href="https://github.com/poingstudios/godot-admob-plugin"  target="_blank" rel="noopener">Poing Studios</a> | Portions of this page are modifications based on work created and <a href="https://developers.google.com/terms/site-policies"  target="_blank" rel="noopener">shared by Google</a> and used according to terms described in the <a href="https://creativecommons.org/licenses/by/4.0/"  target="_blank" rel="noopener">Creative Commons 4.0 Attribution License</a>.
+  &copy; 2020-{current_year} <a href="https://github.com/poingstudios/godot-admob-plugin"  target="_blank" rel="noopener">Poing Studios</a> | Portions of this page are modifications based on work created and <a href="https://developers.google.com/terms/site-policies"  target="_blank" rel="noopener">shared by Google</a> and used according to terms described in the <a href="https://creativecommons.org/licenses/by/4.0/"  target="_blank" rel="noopener">Creative Commons 4.0 Attribution License</a>.
 
 plugins:
   - search

--- a/platforms/android/LICENSE
+++ b/platforms/android/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-present Poing Studios
+Copyright (c) 2020-present Poing Studios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/platforms/godot_editor/addons/admob/LICENSE
+++ b/platforms/godot_editor/addons/admob/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-present Poing Studios
+Copyright (c) 2020-present Poing Studios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/platforms/ios/LICENSE
+++ b/platforms/ios/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-present Poing Studios
+Copyright (c) 2020-present Poing Studios
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #481

## 📋 Summary
Updates the start copyright year in the `LICENSE` files and documentation to **2020** to reflect the initial release of `godot-admob-android` (the original predecessor repository).

## 📝 Changes
- [`LICENSE`](LICENSE): Updated to `Copyright (c) 2020-present Poing Studios`
- [`platforms/android/LICENSE`](platforms/android/LICENSE): Updated to `Copyright (c) 2020-present Poing Studios`
- [`platforms/ios/LICENSE`](platforms/ios/LICENSE): Updated to `Copyright (c) 2020-present Poing Studios`
- [`platforms/godot_editor/addons/admob/LICENSE`](platforms/godot_editor/addons/admob/LICENSE): Updated to `Copyright (c) 2020-present Poing Studios`
- [`mkdocs.yml`](mkdocs.yml): Updated to `&copy; 2020-{current_year}`